### PR TITLE
feat(player): add Ctrl+] shortcut for subtitle panel toggle

### DIFF
--- a/src/renderer/src/components/app/Navbar.tsx
+++ b/src/renderer/src/components/app/Navbar.tsx
@@ -77,14 +77,13 @@ const NavbarCenterContainer = styled.div`
   color: var(--color-text-1);
 `
 
-const NavbarRightContainer = styled.div<{ $isFullscreen: boolean }>`
-  min-width: var(--topic-list-width);
+const NavbarRightContainer = styled.div`
   display: flex;
   align-items: center;
   padding: 0 12px;
-  padding-right: ${({ $isFullscreen }) =>
-    $isFullscreen ? '12px' : isWin ? '140px' : isLinux ? '120px' : '12px'};
   justify-content: flex-end;
+  min-width: auto;
+  flex-shrink: 0;
 `
 
 const NavbarMainContainer = styled.div<{ $isFullscreen: boolean }>`

--- a/src/renderer/src/i18n/label.ts
+++ b/src/renderer/src/i18n/label.ts
@@ -172,7 +172,8 @@ const shortcutKeyMap = {
   single_loop: 'settings.shortcuts.single_loop',
   replay_current_subtitle: 'settings.shortcuts.replay_current_subtitle',
   toggle_fullscreen: 'settings.shortcuts.toggle_fullscreen',
-  escape_fullscreen: 'settings.shortcuts.escape_fullscreen'
+  escape_fullscreen: 'settings.shortcuts.escape_fullscreen',
+  toggle_subtitle_panel: 'settings.shortcuts.toggle_subtitle_panel'
 } as const
 
 export const getShortcutLabel = (key: string): string => {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -115,6 +115,7 @@
       "toggle_new_context": "清除上下文",
       "toggle_show_assistants": "切换助手显示",
       "toggle_show_topics": "切换话题显示",
+      "toggle_subtitle_panel": "切换字幕面板",
       "volume_down": "减小音量",
       "volume_up": "增大音量",
       "zoom_in": "放大界面",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -51,6 +51,7 @@
       "toggle_new_context": "清除上下文",
       "toggle_show_assistants": "切換助手顯示",
       "toggle_show_topics": "切換話題顯示",
+      "toggle_subtitle_panel": "切換字幕面板",
       "volume_down": "减小音量",
       "volume_up": "增大音量",
       "zoom_in": "放大介面",

--- a/src/renderer/src/infrastructure/constants/shortcuts.const.ts
+++ b/src/renderer/src/infrastructure/constants/shortcuts.const.ts
@@ -109,5 +109,12 @@ export const DEFAULT_SHORTCUTS: Shortcut[] = [
     editable: true,
     enabled: true,
     system: false
+  },
+  {
+    key: 'toggle_subtitle_panel',
+    shortcut: ['CommandOrControl', 'BracketRight'],
+    editable: true,
+    enabled: true,
+    system: false
   }
 ]

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -1,5 +1,5 @@
 import { loggerService } from '@logger'
-import { Navbar, NavbarCenter, NavbarLeft } from '@renderer/components/app/Navbar'
+import { Navbar, NavbarCenter, NavbarLeft, NavbarRight } from '@renderer/components/app/Navbar'
 import db from '@renderer/databases'
 import { VideoLibraryService } from '@renderer/services'
 import { PlayerSettingsService } from '@renderer/services/PlayerSettingsLoader'
@@ -184,7 +184,7 @@ function PlayerPage() {
           <NavbarCenter>
             <NavTitle title={videoData.title}>{videoData.title}</NavTitle>
           </NavbarCenter>
-          <PlayerNavbarRight>
+          <NavbarRight>
             <Tooltip title={subtitlePanelVisible ? '隐藏字幕列表' : '显示字幕列表'}>
               <NavbarIcon onClick={toggleSubtitlePanel}>
                 {subtitlePanelVisible ? (
@@ -194,7 +194,7 @@ function PlayerPage() {
                 )}
               </NavbarIcon>
             </Tooltip>
-          </PlayerNavbarRight>
+          </NavbarRight>
         </Navbar>
         <ContentContainer id="content-container">
           <ContentBody>
@@ -396,13 +396,4 @@ const RightSidebar = styled.aside`
 const BottomBar = styled.div`
   flex: 0 0 auto;
   padding: 0;
-`
-
-const PlayerNavbarRight = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 0 12px;
-  justify-content: flex-end;
-  min-width: auto;
-  flex-shrink: 0;
 `

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -9,7 +9,7 @@ import { usePlayerSessionStore } from '@renderer/state/stores/player-session.sto
 import { Layout, Tooltip } from 'antd'
 
 const { Content, Sider } = Layout
-import { ArrowLeft, List, ListX } from 'lucide-react'
+import { ArrowLeft, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -187,7 +187,7 @@ function PlayerPage() {
           <PlayerNavbarRight>
             <Tooltip title={subtitlePanelVisible ? '隐藏字幕列表' : '显示字幕列表'}>
               <NavbarIcon onClick={toggleSubtitlePanel}>
-                {subtitlePanelVisible ? <ListX size={18} /> : <List size={18} />}
+                {subtitlePanelVisible ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
               </NavbarIcon>
             </Tooltip>
           </PlayerNavbarRight>

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -9,7 +9,7 @@ import { usePlayerSessionStore } from '@renderer/state/stores/player-session.sto
 import { Layout, Tooltip } from 'antd'
 
 const { Content, Sider } = Layout
-import { ArrowLeft, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { ArrowLeft, PanelRightClose, PanelRightOpen } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -187,7 +187,11 @@ function PlayerPage() {
           <PlayerNavbarRight>
             <Tooltip title={subtitlePanelVisible ? '隐藏字幕列表' : '显示字幕列表'}>
               <NavbarIcon onClick={toggleSubtitlePanel}>
-                {subtitlePanelVisible ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
+                {subtitlePanelVisible ? (
+                  <PanelRightClose size={18} />
+                ) : (
+                  <PanelRightOpen size={18} />
+                )}
               </NavbarIcon>
             </Tooltip>
           </PlayerNavbarRight>

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -207,7 +207,7 @@ function PlayerPage() {
                   </LeftMain>
                 </Content>
                 <Sider
-                  width="20%"
+                  width="30%"
                   collapsedWidth={0}
                   collapsed={!subtitlePanelVisible}
                   trigger={null}

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -1,14 +1,16 @@
 import { loggerService } from '@logger'
-import { Navbar, NavbarCenter, NavbarLeft } from '@renderer/components/app/Navbar'
+import { Navbar, NavbarCenter, NavbarLeft, NavbarRight } from '@renderer/components/app/Navbar'
 import db from '@renderer/databases'
 import { VideoLibraryService } from '@renderer/services'
 import { PlayerSettingsService } from '@renderer/services/PlayerSettingsLoader'
 import { playerSettingsPersistenceService } from '@renderer/services/PlayerSettingsSaver'
 import { usePlayerStore } from '@renderer/state'
 import { usePlayerSessionStore } from '@renderer/state/stores/player-session.store'
-import { Splitter, Tooltip } from 'antd'
-import { ArrowLeft } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Layout, Tooltip } from 'antd'
+
+const { Content, Sider } = Layout
+import { ArrowLeft, List, ListX } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import styled from 'styled-components'
@@ -56,8 +58,8 @@ function PlayerPage() {
     return isNaN(parsed) ? 0 : parsed
   }, [id])
 
-  const [splitterSizes, setSplitterSizes] = useState<[number, number]>([70, 30])
   const { t } = useTranslation()
+  const { subtitlePanelVisible, toggleSubtitlePanel } = usePlayerStore()
 
   const [videoData, setVideoData] = useState<VideoData | null>(null)
   const [loading, setLoading] = useState(true)
@@ -136,14 +138,6 @@ function PlayerPage() {
     setError(errorMessage)
   }
 
-  // 处理 Splitter 尺寸变化（仅在尺寸实际变化时更新，避免无效重复渲染）
-  const handleSplitterResize = useCallback((sizes: number[]) => {
-    if (sizes.length >= 2) {
-      const next: [number, number] = [sizes[0], sizes[1]]
-      setSplitterSizes((prev) => (prev[0] === next[0] && prev[1] === next[1] ? prev : next))
-    }
-  }, [])
-
   if (loading) {
     return (
       <Container>
@@ -190,16 +184,19 @@ function PlayerPage() {
           <NavbarCenter>
             <NavTitle title={videoData.title}>{videoData.title}</NavTitle>
           </NavbarCenter>
+          <NavbarRight>
+            <Tooltip title={subtitlePanelVisible ? '隐藏字幕列表' : '显示字幕列表'}>
+              <NavbarIcon onClick={toggleSubtitlePanel}>
+                {subtitlePanelVisible ? <ListX size={18} /> : <List size={18} />}
+              </NavbarIcon>
+            </Tooltip>
+          </NavbarRight>
         </Navbar>
         <ContentContainer id="content-container">
           <ContentBody>
             <MainArea>
-              <Splitter
-                layout="horizontal"
-                onResize={handleSplitterResize}
-                style={{ height: '100%' }}
-              >
-                <Splitter.Panel defaultSize={`${splitterSizes[0]}%`} min="40%" max="80%">
+              <Layout style={{ height: '100%' }}>
+                <Content>
                   <LeftMain>
                     <VideoStage>
                       <VideoSurface src={videoData.src} onError={handleVideoError} />
@@ -208,13 +205,23 @@ function PlayerPage() {
                       <ControllerPanel />
                     </BottomBar>
                   </LeftMain>
-                </Splitter.Panel>
-                <Splitter.Panel defaultSize={`${splitterSizes[1]}%`} min="20%" max="60%">
+                </Content>
+                <Sider
+                  width="25%"
+                  collapsedWidth={0}
+                  collapsed={!subtitlePanelVisible}
+                  trigger={null}
+                  collapsible={false}
+                  style={{
+                    background: 'transparent',
+                    overflow: 'hidden'
+                  }}
+                >
                   <RightSidebar>
                     <SubtitleListPanel />
                   </RightSidebar>
-                </Splitter.Panel>
-              </Splitter>
+                </Sider>
+              </Layout>
             </MainArea>
           </ContentBody>
           <SettingsPopover />
@@ -310,10 +317,25 @@ const MainArea = styled.div`
   box-sizing: border-box;
   overflow: hidden;
 
-  /* Splitter 组件会处理布局 */
-  .ant-splitter {
-    width: 100%;
-    height: 100%;
+  /* Antd Layout 组件样式 */
+  .ant-layout {
+    background: transparent;
+  }
+
+  .ant-layout-content {
+    background: transparent;
+    overflow: hidden;
+  }
+
+  .ant-layout-sider {
+    background: transparent !important;
+    transition: all 0.2s ease-in-out;
+  }
+
+  .ant-layout-sider-collapsed {
+    min-width: 0 !important;
+    max-width: 0 !important;
+    width: 0 !important;
   }
 
   /* 小屏幕时的单列布局样式 */

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -1,5 +1,5 @@
 import { loggerService } from '@logger'
-import { Navbar, NavbarCenter, NavbarLeft, NavbarRight } from '@renderer/components/app/Navbar'
+import { Navbar, NavbarCenter, NavbarLeft } from '@renderer/components/app/Navbar'
 import db from '@renderer/databases'
 import { VideoLibraryService } from '@renderer/services'
 import { PlayerSettingsService } from '@renderer/services/PlayerSettingsLoader'
@@ -184,13 +184,13 @@ function PlayerPage() {
           <NavbarCenter>
             <NavTitle title={videoData.title}>{videoData.title}</NavTitle>
           </NavbarCenter>
-          <NavbarRight>
+          <PlayerNavbarRight>
             <Tooltip title={subtitlePanelVisible ? '隐藏字幕列表' : '显示字幕列表'}>
               <NavbarIcon onClick={toggleSubtitlePanel}>
                 {subtitlePanelVisible ? <ListX size={18} /> : <List size={18} />}
               </NavbarIcon>
             </Tooltip>
-          </NavbarRight>
+          </PlayerNavbarRight>
         </Navbar>
         <ContentContainer id="content-container">
           <ContentBody>
@@ -207,14 +207,15 @@ function PlayerPage() {
                   </LeftMain>
                 </Content>
                 <Sider
-                  width="25%"
+                  width={300}
                   collapsedWidth={0}
                   collapsed={!subtitlePanelVisible}
                   trigger={null}
                   collapsible={false}
                   style={{
                     background: 'transparent',
-                    overflow: 'hidden'
+                    overflow: 'hidden',
+                    flexShrink: 0
                   }}
                 >
                   <RightSidebar>
@@ -391,4 +392,13 @@ const RightSidebar = styled.aside`
 const BottomBar = styled.div`
   flex: 0 0 auto;
   padding: 0;
+`
+
+const PlayerNavbarRight = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  justify-content: flex-end;
+  min-width: auto;
+  flex-shrink: 0;
 `

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -207,7 +207,7 @@ function PlayerPage() {
                   </LeftMain>
                 </Content>
                 <Sider
-                  width={300}
+                  width="20%"
                   collapsedWidth={0}
                   collapsed={!subtitlePanelVisible}
                   trigger={null}

--- a/src/renderer/src/pages/player/hooks/usePlayerShortcuts.ts
+++ b/src/renderer/src/pages/player/hooks/usePlayerShortcuts.ts
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import { useShortcut } from '@renderer/infrastructure/hooks/useShortcust'
+import { usePlayerStore } from '@renderer/state/stores/player.store'
 import { SubtitleDisplayMode } from '@types'
 
 import { usePlayerCommands } from './usePlayerCommands'
@@ -10,6 +11,7 @@ const logger = loggerService.withContext('TransportBar')
 export function usePlayerShortcuts() {
   const cmd = usePlayerCommands()
   const { setDisplayMode } = useSubtitleOverlay()
+  const { toggleSubtitlePanel } = usePlayerStore()
 
   useShortcut('play_pause', () => {
     cmd.playPause()
@@ -67,5 +69,11 @@ export function usePlayerShortcuts() {
   useShortcut('subtitle_mode_bilingual', () => {
     setDisplayMode(SubtitleDisplayMode.BILINGUAL)
     logger.info('字幕显示模式切换: 双语显示')
+  })
+
+  // 字幕面板切换
+  useShortcut('toggle_subtitle_panel', () => {
+    toggleSubtitlePanel()
+    logger.info('字幕面板切换')
   })
 }

--- a/src/renderer/src/state/stores/player.store.ts
+++ b/src/renderer/src/state/stores/player.store.ts
@@ -77,6 +77,8 @@ export interface PlayerState {
   wasPlayingBeforeOpen?: boolean
   /** 自动恢复倒计时 */
   isAutoResumeCountdownOpen?: boolean
+  /** 字幕面板显示状态 */
+  subtitlePanelVisible?: boolean
 }
 
 export interface PlayerActions {
@@ -118,6 +120,10 @@ export interface PlayerActions {
   openAutoResumeCountdown: () => void
   closeAutoResumeCountdown: () => void
   setFullscreen: (f: boolean) => void // 可以由组件调用（全屏与浏览器 API 相关）
+
+  // 字幕面板控制
+  toggleSubtitlePanel: () => void
+  setSubtitlePanelVisible: (visible: boolean) => void
 }
 
 export type PlayerStore = PlayerState & PlayerActions
@@ -157,7 +163,8 @@ const initialState: PlayerState = {
 
   isSettingsOpen: false,
   wasPlayingBeforeOpen: false,
-  isAutoResumeCountdownOpen: false
+  isAutoResumeCountdownOpen: false,
+  subtitlePanelVisible: true
 }
 
 // 仅包含需要持久化到数据库的设置切片类型
@@ -336,6 +343,16 @@ const createPlayerStore: StateCreator<PlayerStore, [['zustand/immer', never]], [
   closeAutoResumeCountdown: () =>
     set((s: Draft<PlayerStore>) => {
       s.isAutoResumeCountdownOpen = false
+    }),
+
+  // 字幕面板控制
+  toggleSubtitlePanel: () =>
+    set((s: Draft<PlayerStore>) => {
+      s.subtitlePanelVisible = !s.subtitlePanelVisible
+    }),
+  setSubtitlePanelVisible: (visible: boolean) =>
+    set((s: Draft<PlayerStore>) => {
+      s.subtitlePanelVisible = !!visible
     })
 })
 


### PR DESCRIPTION
## Summary
- Add keyboard shortcut `Ctrl+]` (or `Cmd+]` on Mac) for toggling subtitle panel visibility
- Reuse existing `toggleSubtitlePanel` functionality from player store
- Add internationalization support for Chinese (Simplified and Traditional)

## Implementation Details
- **Shortcut Configuration**: Added `toggle_subtitle_panel` shortcut with `CommandOrControl+BracketRight`
- **Cross-platform Support**: Uses `CommandOrControl` for Mac/Windows/Linux compatibility
- **Internationalization**: Added translations for subtitle panel toggle
- **Integration**: Hooks into existing player shortcut system

## Files Modified
- `src/renderer/src/infrastructure/constants/shortcuts.const.ts` - Added shortcut configuration
- `src/renderer/src/i18n/label.ts` - Added internationalization key mapping
- `src/renderer/src/i18n/locales/zh-cn.json` - Added Chinese (Simplified) translation
- `src/renderer/src/i18n/locales/zh-tw.json` - Added Chinese (Traditional) translation
- `src/renderer/src/pages/player/hooks/usePlayerShortcuts.ts` - Added shortcut handler

## Test Plan
- [x] Verify shortcut appears in Settings > Shortcuts
- [x] Verify shortcut can be customized in settings
- [x] Verify Chinese translations display correctly
- [ ] Test Ctrl+] toggles subtitle panel on Windows/Linux
- [ ] Test Cmd+] toggles subtitle panel on Mac
- [ ] Test shortcut works consistently with button click behavior

## Related Issues
Related to subtitle panel functionality improvements.