### PR TITLE
fix(build): correct alpha channel update file naming

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -157,6 +157,8 @@ jobs:
         run: |
           echo "🏗️ Building for ${{ matrix.platform }}"
           echo "构建平台: ${{ matrix.platform }}"
+          echo "📦 版本类型: ${{ needs.detect-version.outputs.version_type }}"
+          echo "🔄 更新渠道: ${{ needs.detect-version.outputs.version_type == 'stable' && 'latest' || needs.detect-version.outputs.version_type }}"
           pnpm build
           pnpm exec electron-builder ${{ matrix.target }} --publish never
         env:
@@ -166,6 +168,8 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # 根据版本类型设置更新渠道，stable 版本使用 latest，其他版本使用对应类型名称
+          ELECTRON_BUILDER_CHANNEL: ${{ needs.detect-version.outputs.version_type == 'stable' && 'latest' || needs.detect-version.outputs.version_type }}
 
       - name: List build artifacts
         shell: bash
@@ -199,8 +203,8 @@ jobs:
             dist/*.zip
             dist/*.AppImage
             dist/*.deb
-            dist/latest*.yml
-            dist/latest*.yaml
+            dist/*.yml
+            dist/*.yaml
             dist/*.blockmap
           retention-days: 30
           if-no-files-found: warn
@@ -219,8 +223,8 @@ jobs:
             dist/*.zip
             dist/*.AppImage
             dist/*.deb
-            dist/latest*.yml
-            dist/latest*.yaml
+            dist/*.yml
+            dist/*.yaml
             dist/*.blockmap
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -124,6 +124,5 @@ publish:
   vPrefixedTagName: true
   releaseType: draft
   publishAutoUpdate: true
-generateUpdatesFilesForAllChannels: true
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/


### PR DESCRIPTION
## Summary
修复 alpha 渠道发布时生成错误 yml 文件名的问题

- 移除 `generateUpdatesFilesForAllChannels: true` 配置
- 添加动态 `ELECTRON_BUILDER_CHANNEL` 环境变量
- 更新构件路径以支持渠道特定的 yml 文件

## Problem
当使用 GitHub Actions 手动发布 alpha 版本（v1.0.0-alpha.1）时，生成的更新文件是 `latest.yml`，这不符合 Electron Builder 的标准做法。alpha 渠道应该生成 `alpha.yml` 和 `alpha-mac.yml` 文件。

## Solution
1. **移除全局配置**: 删除 `electron-builder.yml` 中的 `generateUpdatesFilesForAllChannels: true`
2. **动态渠道设置**: 在 GitHub Actions 中根据版本类型动态设置 `ELECTRON_BUILDER_CHANNEL` 环境变量
3. **文件路径更新**: 修改构件上传路径从 `latest*.yml` 到 `*.yml` 以支持所有渠道

## Changes
- 🔧 **electron-builder.yml**: 移除 `generateUpdatesFilesForAllChannels` 配置
- 🚀 **.github/workflows/build-and-release.yml**: 
  - 添加 `ELECTRON_BUILDER_CHANNEL` 环境变量
  - 更新构件上传路径
  - 添加调试输出显示版本类型和渠道

## Validation
现在当选择 alpha 渠道发布时，将正确生成：
- Windows: `alpha.yml` 
- macOS: `alpha-mac.yml`

符合 Electron Builder 标准，支持渠道特定的自动更新。

## Test plan
- [x] 手动验证配置更改正确
- [ ] 运行 GitHub Actions 构建验证文件命名
- [ ] 确认 alpha 更新文件正确生成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved release pipeline to set update channels based on version type (stable maps to “latest”; others use their type).
  - Broadened published update metadata to include all .yml/.yaml files for releases and artifacts.
  - Stopped generating update files for all channels by default, aligning outputs with the selected channel.
- Bug Fixes
  - Auto-update behavior now targets the correct channel and publishes the appropriate metadata for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->