### PR TITLE
feat(sidebar): 禁用收藏按钮并添加开发中提示

### DIFF
--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -99,7 +99,11 @@ const MainMenus: FC = () => {
     <>
       {Object.entries(menuItems).map(([key, item]) => {
         const isActive = isRoute(item.path) === 'active'
-        const tooltipTitle = item.disabled ? '' : item.label
+        const tooltipTitle = item.disabled
+          ? key === 'favorites'
+            ? t('common.favorites_developing')
+            : item.label
+          : item.label
 
         return (
           <Tooltip key={key} title={tooltipTitle} placement="right" mouseEnterDelay={0.8}>
@@ -107,7 +111,10 @@ const MainMenus: FC = () => {
               onClick={item.disabled ? undefined : () => navigate(item.path)}
               className={isActive ? 'active' : ''}
             >
-              <Icon theme={theme} className={isActive ? 'active' : ''}>
+              <Icon
+                theme={theme}
+                className={`${isActive ? 'active' : ''} ${item.disabled ? 'disabled' : ''}`}
+              >
                 {item.icon}
               </Icon>
             </StyledLink>
@@ -170,6 +177,21 @@ const Icon = styled.div<{ theme: string }>`
     cursor: pointer;
     .icon {
       color: var(--color-icon-white);
+    }
+  }
+  &.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    .icon {
+      color: var(--color-text-secondary);
+    }
+  }
+  &.disabled:hover {
+    background-color: transparent;
+    opacity: 0.4;
+    cursor: not-allowed;
+    .icon {
+      color: var(--color-text-secondary);
     }
   }
   &.active {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1,5 +1,8 @@
 {
   "common": {
+    "favorites": "Favorites",
+    "favorites_developing": "This feature is under development",
+    "home": "Home",
     "language": "language"
   },
   "docs": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -5,6 +5,7 @@
   "common": {
     "cancel": "取消",
     "favorites": "收藏",
+    "favorites_developing": "该功能正在开发中",
     "grid_view": "矩阵视图",
     "home": "主页",
     "language": "语言",


### PR DESCRIPTION
## Summary

- 为侧边栏收藏按钮添加禁用状态和开发中提示
- 优化用户体验，避免用户对未完成功能的困惑

## Changes

### 🎨 UI/UX 改进
- 收藏按钮现在显示为禁用状态（透明度 0.4）
- 添加 `cursor: not-allowed` 表示不可点击
- 禁用状态下不响应hover效果

### 🌐 国际化支持
- 新增中文提示：`"favorites_developing": "该功能正在开发中"`
- 新增英文提示：`"favorites_developing": "This feature is under development"`

### ⚡ 交互优化
- Hover时显示友好的开发中提示
- 按钮点击事件在禁用状态下不执行

## 技术细节

- 修改了 `Sidebar.tsx` 中的tooltip逻辑
- 为Icon组件添加了 `.disabled` CSS类
- 遵循项目现有的styled-components架构
- 使用项目统一的国际化系统

## 测试

✅ TypeScript类型检查通过  
✅ ESLint代码风格检查通过  
✅ 符合项目开发规范

## 截图/演示

收藏按钮现在：
- 视觉上显示为禁用状态
- Hover时显示"该功能正在开发中"提示
- 无法点击和导航