### PR TITLE
fix(ci): resolve Windows build shell syntax compatibility issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
         run: pnpm install
 
       - name: Build for ${{ matrix.platform }}
+        shell: bash
         run: |
           echo "🏗️ Building for ${{ matrix.platform }}"
           echo "构建平台: ${{ matrix.platform }}"


### PR DESCRIPTION
## Summary
- Fix Windows build failure caused by PowerShell not recognizing bash syntax
- Add `shell: bash` declaration to ensure cross-platform compatibility in GitHub Actions

## Problem
The Windows build was failing with the error:
```
Missing '(' after 'if' in if statement.
```

This occurred because the GitHub Actions Windows runner uses PowerShell by default, which doesn't recognize bash conditional syntax `if [[ ... ]]`.

## Solution
- Added `shell: bash` declaration to the "Build for platform" step
- Ensures all platforms use the same bash environment for script execution
- Maintains existing bash syntax while fixing cross-platform compatibility

## Test Plan
- [x] Verified that GitHub Actions Windows runners support bash shell
- [x] Confirmed the fix addresses the specific PowerShell syntax error
- [ ] Monitor next Windows build to ensure the fix works

## Files Changed
- `.github/workflows/release.yml` - Added shell declaration for cross-platform compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the continuous integration build step to run with a consistent shell across all platforms, improving reliability of build scripts.
  * Build logs may display updated or simplified step labels as part of this change.
  * No changes to application features, performance, or behavior.
  * Release and publishing process remains the same for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->