### PR TITLE
fix(ci): resolve duplicate GitHub releases issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,17 +159,10 @@ jobs:
           echo "🔄 更新渠道: ${{ needs.detect-version.outputs.version_type == 'stable' && 'latest' || needs.detect-version.outputs.version_type }}"
           pnpm build
 
-          # 根据版本类型决定发布策略
-          if [[ "${{ needs.detect-version.outputs.version_type }}" == "dev" || "${{ needs.detect-version.outputs.version_type }}" == "test" ]]; then
-            echo "🚫 Dev/Test version - building without publishing"
-            pnpm exec electron-builder ${{ matrix.target }} --publish never
-          else
-            echo "🚀 Publishing version to GitHub"
-            # 使用 always 策略，无论是否有标签都会发布
-            # electron-builder 会根据版本号自动判断是否为 prerelease
-            echo "📦 Publishing with always strategy (supports both release and prerelease)"
-            pnpm exec electron-builder ${{ matrix.target }} --publish always
-          fi
+          # 构建产物但不发布，交给 semantic-release 统一发布
+          echo "🏗️ Building artifacts without publishing"
+          echo "📦 Semantic-release will handle the GitHub Release creation"
+          pnpm exec electron-builder ${{ matrix.target }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -225,6 +218,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # semantic-release 需要完整的 git 历史
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -251,6 +246,22 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare artifacts for release
+        run: |
+          echo "📦 Preparing artifacts for GitHub Release"
+          mkdir -p dist
+          # 复制所有构建产物到 dist 目录
+          find artifacts -name "*.exe" -o -name "*.dmg" -o -name "*.zip" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.yml" -o -name "*.yaml" -o -name "*.blockmap" | while read file; do
+            cp "$file" dist/
+            echo "📁 Copied: $(basename "$file")"
+          done
+          ls -la dist/
 
       - name: Run Semantic Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,12 @@ on:
         description: 'Release version (e.g., v1.0.0, v1.0.0-beta.1, v1.0.0-alpha.1)'
         required: false
       force_version_type:
-        description: 'Force version type (overrides auto-detection)'
+        description: 'Force version type (dev/test only, others determined by branch)'
         required: false
         type: choice
         options:
           - 'dev'
           - 'test'
-          - 'alpha'
-          - 'beta'
-          - 'stable'
 
 permissions:
   contents: write
@@ -52,16 +49,31 @@ jobs:
 
           # Detect version type
           if [ -n "${{ github.event.inputs.force_version_type }}" ]; then
+            # 手动指定的版本类型（仅限 dev/test）
             VERSION_TYPE="${{ github.event.inputs.force_version_type }}"
+          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+            # main 分支 = stable
+            VERSION_TYPE="stable"
+          elif [[ "${{ github.ref_name }}" == "beta" ]]; then
+            # beta 分支 = beta
+            VERSION_TYPE="beta"
+          elif [[ "${{ github.ref_name }}" == "alpha" ]]; then
+            # alpha 分支 = alpha
+            VERSION_TYPE="alpha"
           elif [[ "$VERSION_NO_V" == *"-dev"* ]]; then
+            # 版本号包含 dev 后缀
             VERSION_TYPE="dev"
           elif [[ "$VERSION_NO_V" == *"-test"* ]]; then
+            # 版本号包含 test 后缀
             VERSION_TYPE="test"
           elif [[ "$VERSION_NO_V" == *"-alpha"* ]]; then
+            # 版本号包含 alpha 后缀
             VERSION_TYPE="alpha"
           elif [[ "$VERSION_NO_V" == *"-beta"* ]]; then
+            # 版本号包含 beta 后缀
             VERSION_TYPE="beta"
           else
+            # 默认为 stable
             VERSION_TYPE="stable"
           fi
 

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -31,12 +31,28 @@ module.exports = {
       }
     ],
 
-    // 创建 Draft Release
+    // 创建 Release 并上传构建产物
     [
       '@semantic-release/github',
       {
-        draft: true,
-        assets: [] // 不上传产物，electron-builder 会自动创建 Release 并上传产物
+        assets: [
+          // Windows 产物
+          { path: 'dist/*.exe', label: 'Windows Installer (${nextRelease.gitTag})' },
+          { path: 'dist/*-win.zip', label: 'Windows Portable (${nextRelease.gitTag})' },
+
+          // macOS 产物
+          { path: 'dist/*.dmg', label: 'macOS Installer (${nextRelease.gitTag})' },
+          { path: 'dist/*-mac.zip', label: 'macOS App Bundle (${nextRelease.gitTag})' },
+
+          // Linux 产物
+          { path: 'dist/*.AppImage', label: 'Linux AppImage (${nextRelease.gitTag})' },
+          { path: 'dist/*.deb', label: 'Linux DEB Package (${nextRelease.gitTag})' },
+
+          // 自动更新文件
+          { path: 'dist/*.yml', label: 'Auto-update manifest' },
+          { path: 'dist/*.yaml', label: 'Auto-update manifest' },
+          { path: 'dist/*.blockmap', label: 'Block map for incremental updates' }
+        ]
       }
     ]
   ]


### PR DESCRIPTION
## Summary
- 修复了 alpha 分支发布时产生两个 GitHub Release 的问题
- 优化了发布工作流的触发选项，简化手动操作

## Changes Made

### 🔧 Release Workflow Fixes
- **移除重复发布**: electron-builder 改为只构建不发布 (`--publish never`)
- **统一发布管理**: semantic-release 负责创建单一 Release 并上传所有构建产物
- **完善产物流转**: 通过 GitHub Actions artifacts 在 jobs 间正确传递构建文件

### 🎛️ Trigger Options Optimization  
- **简化手动选项**: `force_version_type` 仅保留 `dev` 和 `test` 选项
- **智能分支检测**: 
  - `main` 分支 → `stable` 版本
  - `beta` 分支 → `beta` 版本  
  - `alpha` 分支 → `alpha` 版本
- **后备机制**: 版本号后缀检测作为 fallback

### 📦 Semantic Release Config
- 移除 `draft: true` 设置，直接创建正式 Release
- 配置完整的 `assets` 数组，上传所有平台构建产物：
  - Windows: `.exe`, `*-win.zip`
  - macOS: `.dmg`, `*-mac.zip` 
  - Linux: `.AppImage`, `.deb`
  - 自动更新文件: `.yml`, `.yaml`, `.blockmap`

## Expected Results
✅ 单一 GitHub Release（不再有重复）  
✅ 语义化生成的专业 Release 描述  
✅ 完整的跨平台构建产物  
✅ 自动更新文件正确包含  

## Test Plan
- [ ] 合并到 alpha 分支后触发发布
- [ ] 验证只产生一个 Release  
- [ ] 确认 Release 包含 semantic-release 生成的描述
- [ ] 检查所有构建产物都已正确上传

## Files Changed
- `.github/workflows/release.yml` - 发布工作流优化
- `.releaserc.js` - semantic-release 配置更新