### PR TITLE
fix: improve release workflow and build configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,6 @@ on:
       version:
         description: 'Release version (e.g., v1.0.0, v1.0.0-beta.1, v1.0.0-alpha.1)'
         required: false
-      force_version_type:
-        description: 'Force version type (dev/test only, others determined by branch)'
-        required: false
-        type: choice
-        options:
-          - 'dev'
-          - 'test'
 
 permissions:
   contents: write
@@ -47,11 +40,7 @@ jobs:
           # Remove 'v' prefix for processing
           VERSION_NO_V="${VERSION#v}"
 
-          # Detect version type
-          if [ -n "${{ github.event.inputs.force_version_type }}" ]; then
-            # 手动指定的版本类型（仅限 dev/test）
-            VERSION_TYPE="${{ github.event.inputs.force_version_type }}"
-          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
             # main 分支 = stable
             VERSION_TYPE="stable"
           elif [[ "${{ github.ref_name }}" == "beta" ]]; then

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -132,5 +132,5 @@ publish:
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/
 releaseInfo:
-  releaseName: 'EchoPlayer v${version}'
+  releaseName: EchoPlayer v${version}
   releaseNotesFile: 'build/release-notes.md'


### PR DESCRIPTION
## Summary
- Simplify GitHub Actions release workflow by removing force version type parameter
- Fix electron-builder releaseName variable interpolation issue

## Changes
### 🔧 CI/CD Improvements
- **Simplified release workflow**: Removed `force_version_type` input parameter and related logic from `.github/workflows/release.yml`
- **Cleaner version detection**: Version type is now determined solely by branch name (main=stable, beta=beta, alpha=alpha)
- **Removed manual override**: Eliminated the dev/test override option that was complicating the workflow

### 🐛 Build Configuration Fix
- **Fixed releaseName interpolation**: Removed single quotes around `releaseName` in `electron-builder.yml` 
- **Proper variable substitution**: `${version}` variable now correctly interpolates instead of showing literal text
- **Correct release naming**: Release names will now display as "EchoPlayer v1.0.0-alpha.1" instead of "EchoPlayer v${version}"

## Test plan
- [x] Verify GitHub Actions workflow syntax is valid
- [x] Confirm electron-builder configuration parses correctly
- [ ] Test release workflow runs without the removed parameters
- [ ] Validate that built releases show correct version in release name

## Impact
- Streamlined release process with fewer manual intervention points
- Consistent and properly formatted release names in GitHub releases
- Reduced complexity in CI/CD pipeline configuration