### PR TITLE
fix(release): remove custom labels from GitHub release assets

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -37,21 +37,20 @@ module.exports = {
       {
         assets: [
           // Windows 产物
-          { path: 'dist/*.exe', label: 'Windows Installer (${nextRelease.gitTag})' },
-          { path: 'dist/*-win.zip', label: 'Windows Portable (${nextRelease.gitTag})' },
+          'dist/*.exe',
+          'dist/*.zip',
 
           // macOS 产物
-          { path: 'dist/*.dmg', label: 'macOS Installer (${nextRelease.gitTag})' },
-          { path: 'dist/*-mac.zip', label: 'macOS App Bundle (${nextRelease.gitTag})' },
+          'dist/*.dmg',
 
           // Linux 产物
-          { path: 'dist/*.AppImage', label: 'Linux AppImage (${nextRelease.gitTag})' },
-          { path: 'dist/*.deb', label: 'Linux DEB Package (${nextRelease.gitTag})' },
+          'dist/*.AppImage',
+          'dist/*.deb',
 
           // 自动更新文件
-          { path: 'dist/*.yml', label: 'Auto-update manifest' },
-          { path: 'dist/*.yaml', label: 'Auto-update manifest' },
-          { path: 'dist/*.blockmap', label: 'Block map for incremental updates' }
+          'dist/*.yml',
+          'dist/*.yaml',
+          'dist/*.blockmap'
         ]
       }
     ]


### PR DESCRIPTION
## Summary

This PR removes custom labels from GitHub release assets in the semantic-release configuration, allowing asset names to match the original filenames generated by electron-builder.

### Changes Made

- **Simplified asset configuration**: Changed from object format `{ path: '...', label: '...' }` to simple string format for cleaner configuration
- **Removed custom labels**: Eliminated platform-specific labels like `'Windows Installer (${nextRelease.gitTag})'` that obscured actual filenames
- **Updated file patterns**: Corrected Windows portable archive pattern from `*-win.zip` to `*.zip` to match electron-builder output
- **Streamlined macOS assets**: Removed macOS zip assets configuration to match actual build artifacts

### Before

Release assets displayed with custom labels:
- `Windows Installer (v1.0.0-alpha.2)` → actual file: `EchoPlayer-1.0.0-alpha.2-x64-setup.exe`
- `macOS Installer (v1.0.0-alpha.2)` → actual file: `EchoPlayer-1.0.0-alpha.2-x64.dmg`

### After

Release assets displayed with original filenames:
- `EchoPlayer-1.0.0-alpha.2-x64-setup.exe`
- `EchoPlayer-1.0.0-alpha.2-x64.dmg`
- `EchoPlayer-1.0.0-alpha.2-x64.AppImage`

### Benefits

1. **Consistency**: Asset names now match actual filenames from electron-builder
2. **Clarity**: Users can easily identify file types, architectures, and formats
3. **Maintenance**: Simpler configuration without redundant label maintenance
4. **User Experience**: Downloads have predictable, descriptive filenames

## Test Plan

- [ ] Verify semantic-release configuration syntax is valid
- [ ] Test release process with dry-run to ensure assets are properly configured
- [ ] Confirm asset patterns match actual electron-builder output filenames