### PR TITLE
refactor(HomePage): remove watched indicator from video thumbnails

### DIFF
--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -170,22 +170,6 @@ export function HomePage(): React.JSX.Element {
                             <Duration>{video.durationText}</Duration>
                             <TopRightActions>
                               <DeleteButton onClick={() => handleDeleteVideo(video)} />
-                              <WatchedIndicator watched={video.watchProgress >= 1}>
-                                {video.watchProgress >= 1 && (
-                                  <CheckIcon>
-                                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                                      <circle cx="8" cy="8" r="8" fill="#34D399" />
-                                      <path
-                                        d="m4 8 2 2 6-4"
-                                        stroke="white"
-                                        strokeWidth="1.5"
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                      />
-                                    </svg>
-                                  </CheckIcon>
-                                )}
-                              </WatchedIndicator>
                             </TopRightActions>
                           </ThumbnailOverlay>
                           <ProgressBarContainer>
@@ -406,39 +390,6 @@ const Duration = styled.div`
   align-self: flex-end;
   margin-top: auto;
   will-change: transform;
-`
-
-const WatchedIndicator = styled.div<{ watched: boolean }>`
-  display: ${(props) => (props.watched ? 'flex' : 'none')};
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(10px);
-  border-radius: 50%;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  will-change: transform;
-  transform: translateZ(0);
-`
-
-const CheckIcon = styled.div`
-  --check-scale: 0.8;
-  --check-opacity: 0.8;
-
-  transform: scale(var(--check-scale)) translateZ(0);
-  opacity: var(--check-opacity);
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-
-  ${VideoCard}:hover & {
-    --check-scale: 1;
-    --check-opacity: 1;
-  }
-
-  svg {
-    display: block;
-    will-change: transform;
-  }
 `
 
 const ProgressBarContainer = styled.div`


### PR DESCRIPTION
## Summary
- Remove WatchedIndicator component and its associated CheckIcon from video thumbnails
- Clean up unused styled-components for watched status display  
- Simplify video thumbnail overlay interface
- Remove conditional rendering logic for watchProgress >= 1 state

## Changes Made
This refactoring removes the green checkmark indicator that previously showed on video thumbnails when watch progress reached 100%. The changes include:

- **Component Removal**: Eliminated `WatchedIndicator` and `CheckIcon` styled components
- **Logic Cleanup**: Removed conditional rendering based on `video.watchProgress >= 1`
- **Style Cleanup**: Removed associated CSS styles and animations
- **Interface Simplification**: Streamlined the video card overlay structure

## Impact
- Reduces visual complexity in the video thumbnail interface
- Eliminates unused code and improves maintainability
- Simplifies the component structure for future development

## Test Plan
- [x] Verify video thumbnails render correctly without watched indicators
- [x] Confirm no visual regressions in video card layout
- [x] Check that video functionality remains intact