### PR TITLE
fix(player): ensure video always starts paused and sync UI state correctly

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -331,6 +331,8 @@ export class WindowService {
     mainWindow.on('close', (event) => {
       // 如果已经触发退出，直接退出
       if (app.isQuitting) {
+        // 通知渲染进程应用即将退出，让它进行资源清理
+        mainWindow.webContents.send('app-will-quit')
         return app.quit()
       }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,7 @@
 import { loggerService } from '@logger'
 import { AntdProvider, NotificationProvider, ThemeProvider } from '@renderer/contexts'
 import { configSyncService } from '@renderer/services'
+import { appLifecycleService } from '@renderer/services/AppLifecycleService'
 import React, { useEffect, useState } from 'react'
 
 import { SearchOverlay } from './components/SearchOverlay'
@@ -51,6 +52,21 @@ function App(): React.JSX.Element {
     }
 
     initializeApp()
+  }, [])
+
+  // 初始化应用生命周期管理服务
+  useEffect(() => {
+    logger.debug('应用生命周期服务已初始化')
+
+    // 组件卸载时清理服务
+    return () => {
+      try {
+        appLifecycleService.dispose()
+        logger.debug('应用生命周期服务已清理')
+      } catch (error) {
+        logger.error('清理应用生命周期服务时出错:', { error })
+      }
+    }
   }, [])
 
   // 启动页面退出动画完成后完全隐藏

--- a/src/renderer/src/pages/player/PlayerPage.tsx
+++ b/src/renderer/src/pages/player/PlayerPage.tsx
@@ -23,6 +23,7 @@ import {
   SubtitleListPanel,
   VideoSurface
 } from './components'
+import { disposeGlobalOrchestrator } from './hooks/usePlayerEngine'
 import { PlayerPageProvider } from './state/player-page.provider'
 
 const logger = loggerService.withContext('PlayerPage')
@@ -149,6 +150,14 @@ function PlayerPage() {
       // 页面卸载时清理会话态
       usePlayerSessionStore.getState().clear()
       playerSettingsPersistenceService.detach()
+
+      // 清理播放器编排器资源
+      try {
+        disposeGlobalOrchestrator()
+        logger.debug('播放器编排器已清理')
+      } catch (error) {
+        logger.error('清理播放器编排器时出错:', { error })
+      }
     }
   }, [videoId])
 

--- a/src/renderer/src/services/AppLifecycleService.ts
+++ b/src/renderer/src/services/AppLifecycleService.ts
@@ -1,0 +1,169 @@
+import { loggerService } from '@logger'
+
+import { disposeGlobalOrchestrator } from '../pages/player/hooks/usePlayerEngine'
+
+const logger = loggerService.withContext('AppLifecycleService')
+
+/**
+ * 应用生命周期服务
+ * 负责处理应用退出、窗口关闭等场景下的资源清理
+ */
+export class AppLifecycleService {
+  private static instance: AppLifecycleService | null = null
+  private isDisposed = false
+  private cleanupHandlers: Array<() => void> = []
+
+  public static getInstance(): AppLifecycleService {
+    if (!AppLifecycleService.instance) {
+      AppLifecycleService.instance = new AppLifecycleService()
+    }
+    return AppLifecycleService.instance
+  }
+
+  private constructor() {
+    this.setupEventListeners()
+  }
+
+  /**
+   * 注册清理处理器
+   */
+  public registerCleanupHandler(handler: () => void): () => void {
+    this.cleanupHandlers.push(handler)
+
+    // 返回取消注册的函数
+    return () => {
+      const index = this.cleanupHandlers.indexOf(handler)
+      if (index > -1) {
+        this.cleanupHandlers.splice(index, 1)
+      }
+    }
+  }
+
+  /**
+   * 设置事件监听器
+   */
+  private setupEventListeners(): void {
+    // 页面即将卸载时的清理
+    window.addEventListener('beforeunload', this.handleBeforeUnload.bind(this))
+
+    // 页面可见性变化处理（用户切换应用、最小化窗口等）
+    document.addEventListener('visibilitychange', this.handleVisibilityChange.bind(this))
+
+    // 监听主进程发送的退出信号（如果有的话）
+    if (window.electron?.ipcRenderer) {
+      window.electron.ipcRenderer.on('app-will-quit', this.handleAppWillQuit.bind(this))
+    }
+
+    logger.debug('应用生命周期事件监听器已设置')
+  }
+
+  /**
+   * 处理页面即将卸载
+   */
+  private handleBeforeUnload(): void {
+    if (this.isDisposed) return
+
+    try {
+      logger.debug('页面即将卸载，开始清理资源')
+      this.performFullCleanup()
+    } catch (error) {
+      logger.error('页面卸载时清理资源失败:', { error })
+    }
+  }
+
+  /**
+   * 处理页面可见性变化
+   */
+  private handleVisibilityChange(): void {
+    if (document.visibilityState === 'hidden') {
+      logger.debug('页面变为不可见状态')
+      // 这里可以添加暂停播放等逻辑，但不完全清理资源
+    } else if (document.visibilityState === 'visible') {
+      logger.debug('页面变为可见状态')
+      // 页面重新可见时的恢复逻辑
+    }
+  }
+
+  /**
+   * 处理应用即将退出（来自主进程的信号）
+   */
+  private handleAppWillQuit(): void {
+    if (this.isDisposed) return
+
+    try {
+      logger.debug('应用即将退出，开始清理资源')
+      this.performFullCleanup()
+    } catch (error) {
+      logger.error('应用退出时清理资源失败:', { error })
+    }
+  }
+
+  /**
+   * 执行完整的资源清理
+   */
+  private performFullCleanup(): void {
+    if (this.isDisposed) {
+      logger.warn('资源已被清理，跳过重复清理')
+      return
+    }
+
+    logger.debug('开始执行完整资源清理')
+
+    // 1. 清理播放器编排器
+    try {
+      disposeGlobalOrchestrator()
+      logger.debug('播放器编排器已清理')
+    } catch (error) {
+      logger.error('清理播放器编排器失败:', { error })
+    }
+
+    // 2. 执行所有注册的清理处理器
+    try {
+      this.cleanupHandlers.forEach((handler, index) => {
+        try {
+          handler()
+          logger.debug(`清理处理器 ${index} 执行成功`)
+        } catch (error) {
+          logger.error(`清理处理器 ${index} 执行失败:`, { error })
+        }
+      })
+    } catch (error) {
+      logger.error('执行自定义清理处理器时出错:', { error })
+    }
+
+    // 3. 标记为已清理
+    this.isDisposed = true
+    logger.debug('完整资源清理完成')
+  }
+
+  /**
+   * 手动触发清理（供外部调用）
+   */
+  public dispose(): void {
+    this.performFullCleanup()
+
+    // 移除事件监听器
+    try {
+      window.removeEventListener('beforeunload', this.handleBeforeUnload.bind(this))
+      document.removeEventListener('visibilitychange', this.handleVisibilityChange.bind(this))
+
+      if (window.electron?.ipcRenderer) {
+        window.electron.ipcRenderer.removeAllListeners('app-will-quit')
+      }
+
+      logger.debug('应用生命周期事件监听器已移除')
+    } catch (error) {
+      logger.error('移除事件监听器时出错:', { error })
+    }
+  }
+
+  /**
+   * 检查是否已被清理
+   */
+  public isDisposedState(): boolean {
+    return this.isDisposed
+  }
+}
+
+// 创建全局单例实例
+export const appLifecycleService = AppLifecycleService.getInstance()

--- a/src/renderer/src/services/index.ts
+++ b/src/renderer/src/services/index.ts
@@ -1,3 +1,4 @@
+export * from './AppLifecycleService'
 export * from './ConfigSyncService'
 export * from './FileManager'
 export * from './VideoLibrary'


### PR DESCRIPTION
## Summary

- Add AppLifecycleService for proper resource cleanup on app exit
- Implement force pause state synchronization in VideoSurface
- Ensure video element and player engine state consistency
- Fix play/pause button icon state sync issue when re-entering video

## Problem

When users return from homepage during playback and re-enter the video page:
- ✅ Video correctly starts in paused state
- ❌ Play/pause button shows incorrect play icon (should show pause icon)

The issue was due to inconsistent state synchronization between the video element, player engine, and UI components.

## Solution

### 1. AppLifecycleService.ts (169 lines)
- Comprehensive application lifecycle management
- Handles app exit, window close scenarios
- Ensures proper resource cleanup for PlayerOrchestrator
- Provides event listener for `app-will-quit` signal

### 2. Enhanced VideoSurface Component
**Three-layer pause state enforcement:**

**Video Element Connection (lines 36-53)**
```typescript
// Ensure video element always starts paused
if (!node.paused) {
  node.pause()
  logger.debug('视频元素连接时确保暂停状态')
}

// Force sync pause state to player engine
setTimeout(() => {
  if (orchestrator) {
    orchestrator.onPause() // Ensure engine state is paused
    logger.debug('强制同步暂停状态到播放器引擎')
  }
}, 10)
```

**Metadata Loaded Handler (lines 73-83)**
```typescript
// Prevent browser auto-play behavior
if (!video.paused) {
  video.pause()
  logger.debug('视频自动暂停（防止意外播放）')
}

// Force sync pause state to player engine
if (orchestrator) {
  orchestrator.onPause()
  logger.debug('元数据加载完成后强制同步暂停状态到播放器引擎')
}
```

**HTML Attribute Level (line 178)**
```jsx
autoPlay={false} // Explicitly disable auto-play
```

### 3. Integration Updates
- **WindowService.ts**: Send `app-will-quit` message to renderer
- **App.tsx**: Initialize AppLifecycleService in root component
- **PlayerPage.tsx**: Cleanup PlayerOrchestrator on page unmount

## Test Plan

- [x] TypeScript type checking passes
- [x] ESLint and Prettier formatting passes
- [x] All existing functionality remains intact
- [x] Video starts paused when entering page
- [x] Play/pause button shows correct icon state
- [x] State synchronization between all components

## Technical Details

**Root Cause:** 
Browser may trigger `onPlay`/`onPause` events during video element reconnection, causing state desynchronization between:
- Video element (`paused` property)
- MediaClock internal state
- PlayerStore Zustand state
- UI component rendering

**Fix Strategy:**
1. **Preventive**: Add `autoPlay={false}` and force pause on element connection
2. **Corrective**: Force sync pause state to engine at critical moments  
3. **Defensive**: Multiple checkpoints ensure state consistency
4. **Comprehensive**: Proper lifecycle management prevents resource leaks

## Files Changed

- `src/main/services/WindowService.ts` (+2 lines)
- `src/renderer/src/App.tsx` (+16 lines) 
- `src/renderer/src/pages/player/PlayerPage.tsx` (+9 lines)
- `src/renderer/src/pages/player/components/VideoSurface.tsx` (+30 lines)
- `src/renderer/src/services/AppLifecycleService.ts` (+169 lines, new file)
- `src/renderer/src/services/index.ts` (+1 line)

**Total: 6 files changed, 226 insertions(+), 1 deletion(-)**