### PR TITLE
feat(ci): add dynamic workflow names to show release version in actions list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 
+run-name: 🚀 Release ${{ github.event.inputs.version || format('v{0}', github.run_number) }} ${{ github.ref_name != 'main' && format('({0})', github.ref_name) || '' }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- 为 GitHub Actions release workflow 添加动态运行名称显示功能
- 在工作流列表中显示版本号和分支信息，提升可视性

## Changes
- 在 `.github/workflows/release.yml` 中添加 `run-name` 字段
- 支持显示手动输入的版本号或自动生成的版本号
- 非 main 分支会显示分支名称标识

## Benefits
- 👀 在 Actions 列表页面一眼识别发布版本
- 🏷️ 清晰显示分支和版本信息
- 📊 改善工作流管理和跟踪体验

## Display Examples
- `🚀 Release v1.0.0-alpha.1 (alpha)` - 手动版本 + alpha 分支
- `🚀 Release v1.2.0-beta.1 (beta)` - 手动版本 + beta 分支
- `🚀 Release v1.0.0` - 手动版本 + main 分支
- `🚀 Release v123 (alpha)` - 自动版本号 + alpha 分支

## Test plan
- [ ] 验证在不同分支触发 workflow 时显示正确的名称
- [ ] 测试手动输入版本和自动版本号的显示效果