### PR TITLE
fix(ci): sync package.json version with manual trigger input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Sync version from detect-version job
+        shell: bash
+        run: |
+          echo "🔄 同步版本号到 package.json"
+          echo "Current package.json version: $(node -p "require('./package.json').version")"
+          echo "Target version from detect-version: ${{ needs.detect-version.outputs.version }}"
+
+          # 从版本号中移除 'v' 前缀（如果存在）
+          TARGET_VERSION="${{ needs.detect-version.outputs.version }}"
+          VERSION_NO_V="${TARGET_VERSION#v}"
+
+          # 使用 node 脚本更新 package.json 中的版本号
+          node -e "
+            const fs = require('fs');
+            const package = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            package.version = '${VERSION_NO_V}';
+            fs.writeFileSync('package.json', JSON.stringify(package, null, 2) + '\n');
+            console.log('✅ Updated package.json version to:', package.version);
+          "
+
+          echo "Updated package.json version: $(node -p "require('./package.json').version")"
+
       - name: Build for ${{ matrix.platform }}
         shell: bash
         run: |


### PR DESCRIPTION
## 问题描述

修复手动触发 release workflow 时，asset 文件名版本号与 release notes 版本号不一致的问题。

### 问题现象
- 手动触发时指定版本：`v1.0.0-alpha.6`
- Release notes 显示：`alpha.6` ✅
- 上传的 asset 文件名：`alpha.5` ❌

### 根本原因
手动触发时，`detect-version` job 正确解析了输入版本号，但 `release` job 中的 `electron-builder` 仍然使用 `package.json` 中的旧版本号来命名构建产物。

## 解决方案

在 `release` job 的构建步骤前添加版本同步逻辑：
- 从 `detect-version` job 获取正确的版本号
- 动态更新 `package.json` 中的版本号
- 确保 `electron-builder` 使用正确版本进行构建

### 具体修改
- 在 `.github/workflows/release.yml` 中添加 "Sync version from detect-version job" 步骤
- 使用 Node.js 脚本动态更新 package.json 版本号
- 保持向后兼容性（自动触发不受影响）

## 测试计划

修复后建议测试：
1. 手动触发 workflow，指定新版本号
2. 验证构建日志中的版本同步步骤
3. 检查 asset 文件名与 release notes 版本号一致

## 影响范围

- ✅ 修复手动触发时的版本不一致问题
- ✅ 保持自动触发（基于 git tag）的兼容性  
- ✅ 不影响 semantic-release 的正常工作
- ✅ 构建产物文件名将使用正确版本号

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to synchronize the package version with the computed release version before building and publishing.
  * Ensures consistent version numbers across tags, artifacts, and published packages, reducing mismatches.
  * Enhances release traceability and reliability.
  * No changes to app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->