### PR TITLE
fix(player): Fix subtitle navigation when activeCueIndex is -1

### DIFF
--- a/src/renderer/src/pages/player/components/SubtitleListPanel.tsx
+++ b/src/renderer/src/pages/player/components/SubtitleListPanel.tsx
@@ -140,7 +140,7 @@ function SubtitleListPanel({
               data-subtitle-item
               data-index={index}
               data-active={index === currentIndex}
-              active={index === currentIndex}
+              $active={index === currentIndex}
               onClick={() => handleItemClick(index)}
             >
               <TimesRow>
@@ -281,18 +281,19 @@ const ActionButton = styled(Button)`
   border-radius: 12px;
 `
 
-const SubtitleItem = styled.div<{ active: boolean }>`
+const SubtitleItem = styled.div<{ $active: boolean }>`
   display: block;
   margin: 6px 8px;
   padding: 10px 12px;
   cursor: pointer;
   border-radius: 12px;
-  background: ${(p) => (p.active ? 'var(--color-primary-mute)' : 'transparent')};
-  box-shadow: ${(p) => (p.active ? '0 1px 6px rgba(0,0,0,.25)' : 'none')};
+  background: ${(p) => (p.$active ? 'var(--color-primary-mute)' : 'transparent')};
+  box-shadow: ${(p) => (p.$active ? '0 1px 6px rgba(0,0,0,.25)' : 'none')};
   transition: background 0.2s;
 
   &:hover {
-    background: ${(p) => (p.active ? 'var(--color-primary-mute)' : 'var(--color-list-item-hover)')};
+    background: ${(p) =>
+      p.$active ? 'var(--color-primary-mute)' : 'var(--color-list-item-hover)'};
   }
 `
 

--- a/src/renderer/src/pages/player/hooks/usePlayerCommands.ts
+++ b/src/renderer/src/pages/player/hooks/usePlayerCommands.ts
@@ -159,14 +159,42 @@ export function usePlayerCommands() {
     }
 
     const context = orchestrator.getContext()
-    const prevIndex = context.activeCueIndex - 1
+    let prevIndex: number
+
+    // 如果当前没有活跃字幕（activeCueIndex为-1），则基于当前时间找到上一个字幕
+    if (context.activeCueIndex === -1) {
+      // 找到最后一个结束时间小于等于当前时间的字幕
+      prevIndex = -1
+      for (let i = subtitles.length - 1; i >= 0; i--) {
+        if (subtitles[i].endTime <= context.currentTime) {
+          prevIndex = i
+          break
+        }
+      }
+
+      // 如果没找到，则不执行跳转
+      if (prevIndex === -1) {
+        logger.info('Command: goToPreviousSubtitle - no subtitle found before current time', {
+          currentTime: context.currentTime
+        })
+        return
+      }
+    } else {
+      // 正常情况：跳转到上一个字幕
+      prevIndex = context.activeCueIndex - 1
+    }
 
     if (prevIndex >= 0) {
       const prev = subtitles[prevIndex]
       orchestrator.requestUserSeekBySubtitleIndex(prevIndex)
       logger.info('Command: goToPreviousSubtitle executed', {
+        from: context.activeCueIndex,
         to: prev.startTime,
         index: prevIndex
+      })
+    } else {
+      logger.info('Command: goToPreviousSubtitle - already at first subtitle', {
+        currentIndex: context.activeCueIndex
       })
     }
   }, [orchestrator, subtitles])
@@ -178,14 +206,38 @@ export function usePlayerCommands() {
     }
 
     const context = orchestrator.getContext()
-    const nextSubtitleIndex = context.activeCueIndex + 1
+    let nextSubtitleIndex: number
+
+    // 如果当前没有活跃字幕（activeCueIndex为-1），则基于当前时间找到下一个字幕
+    if (context.activeCueIndex === -1) {
+      // 找到第一个开始时间大于当前时间的字幕
+      nextSubtitleIndex = subtitles.findIndex(
+        (subtitle) => subtitle.startTime > context.currentTime
+      )
+
+      // 如果没找到（说明当前时间已经超过了所有字幕），则不执行跳转
+      if (nextSubtitleIndex === -1) {
+        logger.info('Command: goToNextSubtitle - no subtitle found after current time', {
+          currentTime: context.currentTime
+        })
+        return
+      }
+    } else {
+      // 正常情况：跳转到下一个字幕
+      nextSubtitleIndex = context.activeCueIndex + 1
+    }
 
     if (nextSubtitleIndex < subtitles.length) {
       orchestrator.requestUserSeekBySubtitleIndex(nextSubtitleIndex)
       const next = subtitles[nextSubtitleIndex]
       logger.info('Command: goToNextSubtitle executed', {
+        from: context.activeCueIndex,
         to: next.startTime,
         index: nextSubtitleIndex
+      })
+    } else {
+      logger.info('Command: goToNextSubtitle - already at last subtitle', {
+        currentIndex: context.activeCueIndex
       })
     }
   }, [orchestrator, subtitles])


### PR DESCRIPTION
## Summary
- Fix subtitle navigation issue when `activeCueIndex` is -1 after app restart  
- Enhance subtitle jump logic to use current playback time when no active subtitle is set
- Add improved logging for better debugging experience

## Problem
After app restart, when a video is opened and playing at a specific time (e.g., 445.8 seconds), clicking "next subtitle" would incorrectly jump to the first subtitle instead of finding the appropriate next subtitle based on the current playback time.

**Root Cause**: When `activeCueIndex` is -1 (no active subtitle), the `goToNextSubtitle` function calculated `nextIndex = -1 + 1 = 0`, always jumping to the first subtitle.

## Solution
- **`goToNextSubtitle`**: When `activeCueIndex` is -1, find the first subtitle with `startTime > currentTime` instead of blindly jumping to index 0
- **`goToPreviousSubtitle`**: When `activeCueIndex` is -1, find the last subtitle with `endTime <= currentTime` instead of using invalid index calculation
- **Enhanced logging**: Added `from/to` index information for better debugging

## Test Plan
- [x] Restart application
- [x] Open a video file with subtitles  
- [x] Seek or wait until video is playing at a position with subtitles
- [x] Click "next subtitle" button - should jump to correct next subtitle based on current time
- [x] Click "previous subtitle" button - should jump to correct previous subtitle based on current time
- [x] Verify normal subtitle navigation still works during regular playback
- [x] Check that edge cases are handled (no subtitles found, already at first/last subtitle)

## Additional Changes
- Fix styled-components `active` prop to use `$active` prefix to avoid HTML attribute pollution in `SubtitleListPanel`