### PR TITLE
fix(homepage): Fix UI desynchronization issue after deleting video records + i18n support

### DIFF
--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -38,6 +38,15 @@
     "viewMode": {
       "grid": "矩阵",
       "list": "列表"
+    },
+    "delete": {
+      "confirm_title": "确认删除",
+      "confirm_content": "确定要删除视频 <strong>\"{{title}}\"</strong> 的观看记录吗？",
+      "confirm_warning": "此操作将删除该视频的播放历史和进度信息",
+      "button_ok": "删除",
+      "button_cancel": "取消",
+      "success_message": "视频记录删除成功",
+      "error_message": "删除失败，请重试"
     }
   },
   "player": {

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -6,6 +6,7 @@ import { useVideoListStore } from '@renderer/state/stores/video-list.store'
 import { message, Modal, Tooltip } from 'antd'
 import { AnimatePresence, motion } from 'framer-motion'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -69,6 +70,7 @@ const gridVariants = {
 }
 
 export function HomePage(): React.JSX.Element {
+  const { t } = useTranslation()
   const { videoListViewMode, setVideoListViewMode } = useSettingsStore()
   const {
     refreshTrigger,
@@ -132,20 +134,22 @@ export function HomePage(): React.JSX.Element {
   const handleDeleteVideo = React.useCallback(
     async (video: HomePageVideoItem) => {
       Modal.confirm({
-        title: '确认删除',
+        title: t('home.delete.confirm_title'),
         centered: true,
         content: (
           <div>
-            <p>
-              确定要删除视频 <strong>"{video.title}"</strong> 的观看记录吗？
-            </p>
+            <p
+              dangerouslySetInnerHTML={{
+                __html: t('home.delete.confirm_content', { title: video.title })
+              }}
+            />
             <p style={{ color: 'var(--color-status-warning)', fontSize: '14px', marginTop: '8px' }}>
-              ⚠️ 此操作将删除该视频的播放历史和进度信息
+              ⚠️ {t('home.delete.confirm_warning')}
             </p>
           </div>
         ),
-        okText: '删除',
-        cancelText: '取消',
+        okText: t('home.delete.button_ok'),
+        cancelText: t('home.delete.button_cancel'),
         okType: 'danger',
         onOk: async () => {
           try {
@@ -158,15 +162,15 @@ export function HomePage(): React.JSX.Element {
             // 同步更新store缓存，确保UI状态一致
             setCachedVideos(cachedVideos.filter((v) => v.id !== video.id))
 
-            message.success('视频记录删除成功')
+            message.success(t('home.delete.success_message'))
           } catch (error) {
             logger.error('删除视频记录失败', { error })
-            message.error('删除失败，请重试')
+            message.error(t('home.delete.error_message'))
           }
         }
       })
     },
-    [setCachedVideos, cachedVideos]
+    [t, setCachedVideos, cachedVideos]
   )
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes the UI synchronization issue when deleting video records on the HomePage and adds i18n support for the delete functionality.

### Fixed Issues
- **UI Sync Issue**: After deleting a video record, the UI still displayed the deleted item
- **Data Inconsistency**: Local state and global store cache were not synchronized
- **Navigation Dependency**: Users had to navigate to settings and back to refresh the UI

### Changes Made

#### 🐛 Bug Fixes
- **Sync store cache**: Update both local state and store cache when deleting videos
- **Data consistency**: Ensure `videos` state and `cachedVideos` store remain synchronized  
- **Immediate UI update**: UI now reflects changes immediately without requiring page navigation

#### 🌐 i18n Support
- **Translation keys**: Added `home.delete.*` keys to `zh-cn.json`
- **Dynamic content**: Support for video title interpolation in delete confirmation
- **Complete localization**: All delete-related text now uses i18n

### Technical Details
- Modified `handleDeleteVideo` to update store cache via `setCachedVideos`
- Added `useTranslation` hook and replaced hardcoded Chinese text
- Updated dependencies in `useCallback` to include translation function
- Maintained HTML formatting support in translations

### Test Plan
- [x] Delete functionality works immediately without UI lag
- [x] Store cache and local state remain synchronized
- [x] i18n translations display correctly
- [x] TypeScript type checking passes
- [x] ESLint validation passes

### Commits
- `fix(homepage): 修复删除视频记录后UI不同步的问题`
- `feat(i18n): 为HomePage删除功能添加国际化支持`