### PR TITLE
fix(ui): Remove white border shadow from modal buttons in dark mode

### DIFF
--- a/src/renderer/src/assets/styles/ant.scss
+++ b/src/renderer/src/assets/styles/ant.scss
@@ -191,6 +191,7 @@
       height: 36px;
       padding: 0 16px;
       font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif;
+      box-shadow: none !important;
 
       &.ant-btn-default {
         background: var(--color-background-soft);
@@ -284,6 +285,7 @@
   font-weight: 500;
   height: 36px;
   margin-left: 8px;
+  box-shadow: none !important;
 
   &:first-child {
     margin-left: 0;


### PR DESCRIPTION
## Summary
- 修复暗色模式下modal框按钮底部出现白色边框阴影的问题
- 在 `.ant-modal-footer .ant-btn` 中添加 `box-shadow: none !important`
- 在 `.ant-modal-confirm .ant-modal-confirm-btns .ant-btn` 中添加 `box-shadow: none !important`

## Root Cause
问题源于Ant Design在启用CSS变量模式时，自动生成的CSS变量中包含按钮阴影样式：
- `--ant-button-default-shadow: 0 2px 0 rgba(0, 0, 0, 0.02)`
- `--ant-button-primary-shadow: 0 2px 0 rgb(230, 244, 255)`  
- `--ant-button-danger-shadow: 0 2px 0 rgb(255, 242, 240)`

这些阴影在暗色模式下创建了白色/浅色的下边框效果。

## Solution
通过在modal内的按钮样式中强制禁用阴影效果来解决问题。

## Test Plan
- [x] 验证暗色模式下modal按钮不再显示白边
- [x] 验证亮色模式下样式正常
- [x] 验证标准modal和确认对话框都已修复
- [x] 确认不影响其他按钮样式

## Files Changed
- `src/renderer/src/assets/styles/ant.scss`: 添加按钮阴影禁用样式

Closes the white border issue in dark mode modal buttons.