### PR TITLE
feat(player): Implement fullscreen toggle functionality with keyboard shortcuts

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -384,6 +384,43 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
     win && win.webContents.toggleDevTools()
   })
 
+  // 全屏相关 IPC 处理器 / Fullscreen-related IPC handlers
+  ipcMain.handle(IpcChannel.Window_IsFullScreen, (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender)
+    return win ? win.isFullScreen() : false
+  })
+
+  ipcMain.handle(IpcChannel.Window_EnterFullScreen, (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender)
+    if (win && !win.isFullScreen()) {
+      win.setFullScreen(true)
+      // 通知渲染进程全屏状态已改变
+      win.webContents.send(IpcChannel.FullscreenStatusChanged, true)
+      logger.info('Window entered fullscreen')
+    }
+  })
+
+  ipcMain.handle(IpcChannel.Window_ExitFullScreen, (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender)
+    if (win && win.isFullScreen()) {
+      win.setFullScreen(false)
+      // 通知渲染进程全屏状态已改变
+      win.webContents.send(IpcChannel.FullscreenStatusChanged, false)
+      logger.info('Window exited fullscreen')
+    }
+  })
+
+  ipcMain.handle(IpcChannel.Window_ToggleFullScreen, (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender)
+    if (win) {
+      const isCurrentlyFullscreen = win.isFullScreen()
+      win.setFullScreen(!isCurrentlyFullscreen)
+      // 通知渲染进程全屏状态已改变
+      win.webContents.send(IpcChannel.FullscreenStatusChanged, !isCurrentlyFullscreen)
+      logger.info(`Window fullscreen toggled to: ${!isCurrentlyFullscreen}`)
+    }
+  })
+
   // file
   ipcMain.handle(IpcChannel.File_Open, fileManager.open.bind(fileManager))
   ipcMain.handle(IpcChannel.File_OpenPath, fileManager.openPath.bind(fileManager))

--- a/src/renderer/src/pages/player/components/ControllerPanel/controls/FullscreenButton.tsx
+++ b/src/renderer/src/pages/player/components/ControllerPanel/controls/FullscreenButton.tsx
@@ -1,19 +1,29 @@
-import { usePlayerCommands } from '@renderer/pages/player/hooks/usePlayerCommands'
-import { usePlayerStore } from '@renderer/state/stores/player.store'
+import { loggerService } from '@logger'
+import { useFullscreen } from '@renderer/infrastructure/hooks/useFullscreen'
+import { IpcChannel } from '@shared/IpcChannel'
 import { Maximize, Minimize } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { ControlIconButton } from '../styles/controls'
 
+const logger = loggerService.withContext('FullscreenButton')
+
 export default function FullscreenButton() {
   const { t } = useTranslation()
-  const isFullscreen = usePlayerStore((s) => s.isFullscreen)
-  const cmd = usePlayerCommands()
+  const isFullscreen = useFullscreen()
+
+  const handleToggleFullscreen = async () => {
+    try {
+      await window.electron.ipcRenderer.invoke(IpcChannel.Window_ToggleFullScreen)
+    } catch (error) {
+      logger.error('Failed to toggle fullscreen:', { error })
+    }
+  }
 
   return (
     <Button
-      onClick={() => cmd.setFullscreen(!isFullscreen)}
+      onClick={handleToggleFullscreen}
       aria-label="Toggle fullscreen"
       title={
         isFullscreen ? t('player.controls.fullscreen.exit') : t('player.controls.fullscreen.enter')

--- a/src/renderer/src/pages/player/hooks/usePlayerCommands.ts
+++ b/src/renderer/src/pages/player/hooks/usePlayerCommands.ts
@@ -19,7 +19,6 @@ export function usePlayerCommands() {
   const { orchestrator } = usePlayerEngine()
   const subtitles = usePlayerSubtitlesStore((s) => s.subtitles)
   const toggleLoopEnabled = usePlayerStore((s) => s.toggleLoopEnabled)
-  const setFullscreen = usePlayerStore((s) => s.setFullscreen)
 
   // 播放/暂停
   const playPause = useCallback(async () => {
@@ -287,7 +286,6 @@ export function usePlayerCommands() {
     goToNextSubtitle,
 
     // 功能控制
-    toggleLoopEnabled,
-    setFullscreen
+    toggleLoopEnabled
   }
 }


### PR DESCRIPTION
## Summary

- Implement fullscreen toggle functionality with native Electron API
- Add keyboard shortcut (F key) for fullscreen toggle
- Replace player store fullscreen management with native system controls

## Changes

### Main Process (IPC)
- Add `Window_IsFullScreen` handler to check current fullscreen status
- Add `Window_EnterFullScreen` handler to enter fullscreen mode
- Add `Window_ExitFullScreen` handler to exit fullscreen mode  
- Add `Window_ToggleFullScreen` handler to toggle fullscreen state
- Add fullscreen status change notifications to renderer process

### Renderer Process
- **FullscreenButton**: Refactor to use native Electron IPC instead of player store
- **PlayerPage**: Add keyboard event listener for F key fullscreen toggle
- **usePlayerCommands**: Remove deprecated fullscreen methods
- **useFullscreen hook**: Utilize existing hook for consistent state management

## Test Plan

- [x] Fullscreen button toggles window fullscreen state correctly
- [x] F key keyboard shortcut works in player page
- [x] Fullscreen state is properly synchronized with UI
- [x] No interference with form inputs (keyboard shortcut properly scoped)
- [x] Native system fullscreen controls work as expected

## Technical Notes

This implementation uses Electron's native fullscreen API (`BrowserWindow.setFullScreen()`) instead of managing fullscreen state in the application store, which provides better integration with the operating system and more reliable fullscreen behavior.