### PR TITLE
fix(player): Prevent subtitle overlay interactions from triggering video play/pause

### DIFF
--- a/src/renderer/src/pages/player/components/SubtitleOverlay.tsx
+++ b/src/renderer/src/pages/player/components/SubtitleOverlay.tsx
@@ -196,6 +196,7 @@ export const SubtitleOverlay = memo(function SubtitleOverlay({
       if (isResizing) return
 
       event.preventDefault()
+      event.stopPropagation() // 阻止事件冒泡，防止触发VideoSurface的点击事件
       const startX = event.clientX
       const startY = event.clientY
       const startPosition = { x: position.x, y: position.y }
@@ -254,7 +255,7 @@ export const SubtitleOverlay = memo(function SubtitleOverlay({
   const handleResizeMouseDown = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault()
-      event.stopPropagation()
+      event.stopPropagation() // 阻止事件冒泡，防止触发VideoSurface的点击事件
 
       const startX = event.clientX
       const startY = event.clientY
@@ -329,11 +330,17 @@ export const SubtitleOverlay = memo(function SubtitleOverlay({
     // TODO: 实现单词点击的 popup 功能
   }, [])
 
+  // === 通用点击处理（阻止冒泡到VideoSurface） ===
+  const handleClick = useCallback((event: React.MouseEvent) => {
+    // 阻止所有点击事件冒泡到VideoSurface，防止触发播放/暂停
+    event.stopPropagation()
+  }, [])
+
   // === ResizeHandle 双击扩展处理 ===
   const handleResizeDoubleClick = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault()
-      event.stopPropagation()
+      event.stopPropagation() // 阻止事件冒泡，防止触发VideoSurface的点击事件
 
       const maxWidth = 95 // 最大宽度95%
 
@@ -395,6 +402,7 @@ export const SubtitleOverlay = memo(function SubtitleOverlay({
       $backgroundType={backgroundStyle.type}
       $opacity={backgroundStyle.opacity}
       onMouseDown={handleMouseDown}
+      onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       data-testid="subtitle-overlay"

--- a/src/renderer/src/pages/player/components/VideoSurface.tsx
+++ b/src/renderer/src/pages/player/components/VideoSurface.tsx
@@ -3,6 +3,7 @@ import { usePlayerStore } from '@renderer/state/stores/player.store'
 import { useCallback, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 
+import { usePlayerCommands } from '../hooks/usePlayerCommands'
 import { usePlayerEngine } from '../hooks/usePlayerEngine'
 import AutoResumeCountdown from './AutoResumeCountdown'
 import SubtitleOverlay from './SubtitleOverlay'
@@ -28,6 +29,13 @@ function VideoSurface({ src, onLoadedMetadata, onError }: VideoSurfaceProps) {
   const pause = usePlayerStore((s) => s.pause)
 
   const { connectVideoElement, getMediaEventHandlers, orchestrator } = usePlayerEngine()
+  const { playPause } = usePlayerCommands()
+
+  // 处理点击播放/暂停
+  const handleSurfaceClick = useCallback(() => {
+    playPause()
+    logger.debug('点击触发播放/暂停')
+  }, [playPause])
 
   // 稳定的 video 元素引用处理
   const handleVideoRef = useCallback(
@@ -194,7 +202,19 @@ function VideoSurface({ src, onLoadedMetadata, onError }: VideoSurfaceProps) {
   }, [])
 
   return (
-    <Surface ref={surfaceRef} role="region" aria-label="video-surface" data-testid="video-surface">
+    <Surface
+      ref={surfaceRef}
+      role="button"
+      data-testid="video-surface"
+      onClick={handleSurfaceClick}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleSurfaceClick()
+        }
+      }}
+    >
       <StyledVideo
         ref={handleVideoRef}
         src={src}
@@ -243,6 +263,7 @@ const Surface = styled.div`
   align-items: center;
   justify-content: center;
   background: #000;
+  cursor: pointer;
 
   /* 为字幕覆盖层提供定位上下文 */
   overflow: hidden;


### PR DESCRIPTION
## Summary
修复拖动字幕覆盖层时意外触发视频播放/暂停功能的问题

- 在字幕覆盖层的所有交互事件（拖拽、调整尺寸、点击）中添加 `event.stopPropagation()` 来阻止事件冒泡
- 确保用户在操作字幕覆盖层时不会意外触发视频播放控制
- 保持视频表面正常的点击播放/暂停功能

## Changes Made
- **SubtitleOverlay.tsx**: 在拖拽、调整尺寸和点击事件处理器中添加事件冒泡阻止机制
- **VideoSurface.tsx**: 完善点击播放/暂停功能的实现

## Test Plan
- [x] 验证字幕覆盖层可以正常拖动而不触发播放/暂停
- [x] 验证调整字幕尺寸时不会影响视频状态
- [x] 验证双击扩展字幕区域不会触发播放控制
- [x] 验证视频表面的点击播放/暂停功能仍然正常工作
- [x] 确保所有字幕覆盖层交互都被正确隔离

## Issue Reference
修复了用户在拖动字幕覆盖层时意外触发视频播放暂停的问题，提升了用户体验。