### PR TITLE
ci(sync): add main-to-beta sync workflow

### DIFF
--- a/.github/workflows/sync-main-to-beta.yml
+++ b/.github/workflows/sync-main-to-beta.yml
@@ -1,0 +1,37 @@
+name: Sync main -> beta
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create sync branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin beta
+          git checkout -b chore/sync-main-to-beta origin/beta
+          # 线性历史优先：尝试 fast-forward 或 rebase
+          git merge --ff-only origin/main || git rebase origin/main
+          git push -u origin chore/sync-main-to-beta
+
+      - name: Open PR main -> beta
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: 'chore(sync): main -> beta'
+          body: 'Auto sync main into beta after a merge to main.'
+          base: beta
+          branch: chore/sync-main-to-beta
+          labels: sync, automated
+          draft: false


### PR DESCRIPTION
## Summary
- add workflow to sync main branch into beta and open PR

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3871f535c8331be57f88b872a6a0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated GitHub Actions workflow that, on updates to the main branch, creates a labeled pull request into the beta branch using a dedicated sync branch.
  * Ensures linear history where possible (fast-forward or rebase) and runs with appropriate repository permissions.
  * Improves release flow visibility by opening non-draft PRs with standardized titles and bodies for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->