### PR TITLE
fix(subtitle): prevent overlay showing content during subtitle gaps

### DIFF
--- a/src/renderer/src/pages/player/hooks/useSubtitleOverlay.ts
+++ b/src/renderer/src/pages/player/hooks/useSubtitleOverlay.ts
@@ -36,6 +36,9 @@ export function useSubtitleOverlay(): SubtitleOverlay {
   // 字幕引擎
   const { currentSubtitle, currentIndex } = useSubtitleEngine()
 
+  // 当前播放时间
+  const currentTime = usePlayerStore((s) => s.currentTime)
+
   const subtitleOverlayConfig = usePlayerStore((s) => s.subtitleOverlay)
   const setSubtitleOverlay = usePlayerStore((s) => s.setSubtitleOverlay)
 
@@ -54,10 +57,17 @@ export function useSubtitleOverlay(): SubtitleOverlay {
 
   // === 计算是否应该显示 ===
   const shouldShow = useMemo(() => {
-    return (
-      subtitleOverlayConfig.displayMode !== SubtitleDisplayMode.NONE && currentSubtitleData !== null
-    )
-  }, [subtitleOverlayConfig.displayMode, currentSubtitleData])
+    // 基础条件：显示模式不为 NONE 且有字幕数据
+    if (subtitleOverlayConfig.displayMode === SubtitleDisplayMode.NONE || !currentSubtitleData) {
+      return false
+    }
+
+    // 时间边界检查：确保当前播放时间在字幕的时间范围内
+    const isInTimeRange =
+      currentTime >= currentSubtitleData.startTime && currentTime <= currentSubtitleData.endTime
+
+    return isInTimeRange
+  }, [subtitleOverlayConfig.displayMode, currentSubtitleData, currentTime])
 
   // === 计算显示文本 ===
   const displayText = useMemo(() => {


### PR DESCRIPTION
## Summary
- 修复字幕覆盖层在字幕间隙期间仍显示上一个字幕内容的问题
- 在 useSubtitleOverlay hook 中添加时间边界检查
- 确保覆盖层只在播放时间精确在字幕时间范围内时显示内容

## Changes Made
- **useSubtitleOverlay.ts**: 在 `shouldShow` 逻辑中添加 `currentTime >= startTime && currentTime <= endTime` 的时间边界检查
- 保持 useSubtitleEngine 不变，避免影响 SubtitleListPanel 的高亮功能

## Test Plan
- [x] 验证字幕覆盖层在字幕时间范围内正常显示
- [x] 验证字幕覆盖层在字幕间隙期间显示为空
- [x] 验证字幕列表面板的高亮功能不受影响
- [x] 确保不破坏现有的字幕引擎功能

## Technical Details
**问题根因**: `useSubtitleEngine` 的 `findIndexByTime` 函数会返回最近的前一个字幕索引，即使播放时间已经超过该字幕的 `endTime`。这导致字幕覆盖层在字幕间隙期间仍然显示上一个字幕内容。

**解决方案**: 在 `useSubtitleOverlay` 层面添加额外的时间边界验证，而不修改底层的字幕引擎逻辑，确保：
1. 字幕覆盖层只在精确时间范围内显示
2. 字幕列表面板继续正常工作（需要知道"最近的字幕"来保持高亮）
3. 其他依赖 useSubtitleEngine 的组件不受影响

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subtitle overlay now displays only within each subtitle’s time range, improving sync with playback.
  * Prevents subtitles from appearing when the overlay is turned off or when no subtitle is available.
  * Reduces flicker and inconsistent visibility during playback and scrubbing by using current playback time.
  * Enhances reliability of subtitle visibility during seeks and pauses with no UI changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->