### PR TITLE
fix(updater): remove detailed release notes from system update dialog

### DIFF
--- a/src/main/services/AppUpdater.ts
+++ b/src/main/services/AppUpdater.ts
@@ -274,21 +274,13 @@ export default class AppUpdater {
     if (!this.releaseInfo) {
       return
     }
-    // const locale = locales[configManager.getLanguage()]
-    // const { update: updateLocale } = locale.translation
-
-    let detail = this.formatReleaseNotes(this.releaseInfo.releaseNotes)
-    if (detail === '') {
-      detail = 'No release notes'
-    }
 
     dialog
       .showMessageBox({
         type: 'info',
         title: 'Update available',
         icon,
-        message: 'A new version is available. Do you want to download it now?',
-        detail,
+        message: `A new version (${this.releaseInfo.version}) is available. Do you want to install it now?\n\nYou can view the release notes in Settings > About.`,
         buttons: ['Later', 'Install'],
         defaultId: 1,
         cancelId: 0
@@ -301,18 +293,6 @@ export default class AppUpdater {
           mainWindow.webContents.send(IpcChannel.UpdateDownloadedCancelled)
         }
       })
-  }
-
-  private formatReleaseNotes(releaseNotes: string | ReleaseNoteInfo[] | null | undefined): string {
-    if (!releaseNotes) {
-      return ''
-    }
-
-    if (typeof releaseNotes === 'string') {
-      return releaseNotes
-    }
-
-    return releaseNotes.map((note) => note.note).join('\n')
   }
 }
 interface GithubReleaseInfo {
@@ -334,8 +314,4 @@ interface GithubReleaseInfo {
     download_count: number
     created_at: string
   }>
-}
-interface ReleaseNoteInfo {
-  readonly version: string
-  readonly note: string | null
 }


### PR DESCRIPTION
## Summary
- Remove detailed release notes from system update dialog to prevent window overflow
- Display only essential update information with version number  
- Direct users to Settings > About page for full release notes
- Clean up unused code (formatReleaseNotes method and ReleaseNoteInfo interface)

## Problem
When clicking "安装更新" (Install Update) in the About page, a system-level dialog appears with update logs. If the release notes are too long, the system dialog overflows beyond the screen height, causing the Install button to be hidden and inaccessible to users.

## Solution
Simplified the system update dialog to show only essential information:
- New version number
- Clear call-to-action
- Reference to Settings > About for full release notes

This maintains a clean user experience while ensuring all buttons remain accessible.

## Test plan
- [ ] Verify update dialog appears with simplified content
- [ ] Confirm Install button is always visible regardless of release note length
- [ ] Check that full release notes are still available in Settings > About page