### PR TITLE
fix(subtitle): resolve overlay pause/seek update delays with immediate state sync

### DIFF
--- a/src/renderer/src/pages/player/components/VideoErrorRecovery.tsx
+++ b/src/renderer/src/pages/player/components/VideoErrorRecovery.tsx
@@ -166,7 +166,7 @@ function VideoErrorRecovery({
         width={480}
         closable={false}
         maskClosable={false}
-        destroyOnClose
+        destroyOnHidden
       >
         <ModalContent>
           <VideoTitle title={videoTitle}>{videoTitle}</VideoTitle>

--- a/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
+++ b/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
@@ -463,9 +463,7 @@ export class PlayerOrchestrator {
 
     // 重置播放器状态（清理意图、重置字幕锁定、重载策略）
     this.resetOnUserSeek()
-    this.context.currentTime = cue.startTime
-    this.context.activeCueIndex = index
-
+    this.updateContext({ currentTime: cue.startTime, activeCueIndex: index })
     // 标记用户跳转状态，暂时禁用自动保存
     import('@renderer/services/PlayerSettingsSaver').then(
       ({ playerSettingsPersistenceService }) => {

--- a/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
+++ b/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
@@ -418,6 +418,18 @@ export class PlayerOrchestrator {
     // 重置播放器状态（清理意图、重置字幕锁定、重载策略）
     this.resetOnUserSeek()
 
+    // 标记用户跳转状态，暂时禁用自动保存
+    import('@renderer/services/PlayerSettingsSaver').then(
+      ({ playerSettingsPersistenceService }) => {
+        playerSettingsPersistenceService.markUserSeeking()
+      }
+    )
+
+    // 立即更新 store 中的 currentTime，确保 UI 组件能立即响应
+    if (this.stateUpdater) {
+      this.stateUpdater.setCurrentTime(to)
+    }
+
     // 执行跳转
     const clampedTime = Math.max(0, Math.min(this.context.duration || Infinity, to))
     this.videoController.seek(clampedTime)
@@ -453,6 +465,18 @@ export class PlayerOrchestrator {
     this.resetOnUserSeek()
     this.context.currentTime = cue.startTime
     this.context.activeCueIndex = index
+
+    // 标记用户跳转状态，暂时禁用自动保存
+    import('@renderer/services/PlayerSettingsSaver').then(
+      ({ playerSettingsPersistenceService }) => {
+        playerSettingsPersistenceService.markUserSeeking()
+      }
+    )
+
+    // 立即更新 store 中的 currentTime，确保字幕 overlay 能立即响应
+    if (this.stateUpdater) {
+      this.stateUpdater.setCurrentTime(cue.startTime)
+    }
 
     // 执行跳转
     const clampedTime = Math.max(0, Math.min(this.context.duration || Infinity, cue.startTime))

--- a/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
+++ b/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
@@ -475,10 +475,11 @@ export class PlayerOrchestrator {
 
     // 重置播放器状态（清理意图、重置字幕锁定、重载策略）
     this.resetOnUserSeek()
-    this.updateContext({ currentTime: cue.startTime, activeCueIndex: index })
 
-    // 锁定字幕状态机，防止 SubtitleSyncStrategy 立即覆盖用户选择
+    // 立即锁定字幕状态机，防止 SubtitleSyncStrategy 在 updateContext 时覆盖用户选择
     this.subtitleLockFSM.lock('user_seek', index)
+
+    this.updateContext({ currentTime: cue.startTime, activeCueIndex: index })
 
     // 设置定时器，2秒后自动解锁，允许自动同步策略重新生效
     this.userSeekTaskId = this.clockScheduler.scheduleAfter(

--- a/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
+++ b/src/renderer/src/pages/player/engine/PlayerOrchestrator.ts
@@ -611,6 +611,7 @@ export class PlayerOrchestrator {
   }
 
   onSeeking(): void {
+    this.mediaClock.startSeeking()
     this.stateUpdater?.setSeeking?.(true)
   }
 

--- a/src/renderer/src/pages/player/engine/intent/IntentStrategyManager.ts
+++ b/src/renderer/src/pages/player/engine/intent/IntentStrategyManager.ts
@@ -190,7 +190,6 @@ export class IntentStrategyManager {
     for (const strategy of strategiesToReload) {
       try {
         this.registerStrategy(strategy)
-        logger.debug(`重新挂载策略: ${strategy.name}`)
       } catch (error) {
         logger.error(`重新挂载策略 ${strategy.name} 失败:`, { error })
       }

--- a/src/renderer/src/pages/player/hooks/usePlayerEngine.ts
+++ b/src/renderer/src/pages/player/hooks/usePlayerEngine.ts
@@ -55,6 +55,10 @@ function getOrCreateGlobalStateUpdater(): StateUpdater {
         // TODO: 如果需要，可以在 player store 中添加 ended 状态
         logger.debug('Ended state updated:', { ended })
       },
+      setActiveCueIndex: (index: number) => {
+        usePlayerStore.getState().setActiveCueIndex(index)
+        logger.debug('Active cue index updated:', { index })
+      },
       // UI状态更新处理
       updateUIState: (updates: { openAutoResumeCountdown?: boolean }) => {
         logger.debug('Processing UI state updates:', { updates })

--- a/src/renderer/src/pages/player/hooks/useSubtitleEngine.ts
+++ b/src/renderer/src/pages/player/hooks/useSubtitleEngine.ts
@@ -19,6 +19,7 @@ interface SubtitleEngine {
 export function useSubtitleEngine(): SubtitleEngine {
   const subtitles = useSubtitles()
   const currentTime = usePlayerStore((s) => s.currentTime)
+  const storeActiveCueIndex = usePlayerStore((s) => s.activeCueIndex)
 
   // 创建时间索引，用于二分查找优化
   const timeIndex = useMemo(() => {
@@ -78,10 +79,15 @@ export function useSubtitleEngine(): SubtitleEngine {
     }
   }, [findIndexByTime, subtitles])
 
-  // 当前字幕和索引
+  // 当前字幕和索引 - 优先使用 PlayerOrchestrator 的 activeCueIndex，回退到基于时间的计算
   const currentIndex = useMemo(() => {
+    // 如果 PlayerOrchestrator 提供了有效的 activeCueIndex，直接使用
+    if (storeActiveCueIndex >= 0 && storeActiveCueIndex < subtitles.length) {
+      return storeActiveCueIndex
+    }
+    // 否则回退到基于时间的计算
     return findIndexByTime(currentTime)
-  }, [findIndexByTime, currentTime])
+  }, [storeActiveCueIndex, subtitles.length, findIndexByTime, currentTime])
 
   const currentSubtitle = useMemo(() => {
     return currentIndex >= 0 ? subtitles[currentIndex] : null

--- a/src/renderer/src/pages/player/hooks/useSubtitleOverlay.ts
+++ b/src/renderer/src/pages/player/hooks/useSubtitleOverlay.ts
@@ -62,11 +62,21 @@ export function useSubtitleOverlay(): SubtitleOverlay {
       return false
     }
 
-    // 时间边界检查：确保当前播放时间在字幕的时间范围内
+    // 正常的时间边界检查：确保当前播放时间在字幕的时间范围内
     const isInTimeRange =
       currentTime >= currentSubtitleData.startTime && currentTime <= currentSubtitleData.endTime
 
-    return isInTimeRange
+    // 如果在时间范围内，直接显示
+    if (isInTimeRange) {
+      return true
+    }
+
+    // 智能容差机制：处理用户跳转时的短暂时间不同步问题
+    // 如果当前时间接近字幕开始时间，也应该显示（防止跳转闪烁）
+    const timeDiffToStart = Math.abs(currentTime - currentSubtitleData.startTime)
+    const isNearStart = timeDiffToStart <= 2.0 // 2秒容差，处理跳转延迟
+
+    return isNearStart
   }, [subtitleOverlayConfig.displayMode, currentSubtitleData, currentTime])
 
   // === 计算显示文本 ===

--- a/src/renderer/src/services/PlayerSettingsLoader.ts
+++ b/src/renderer/src/services/PlayerSettingsLoader.ts
@@ -41,6 +41,7 @@ export class PlayerSettingsService {
       duration: 0,
       paused: true,
       isFullscreen: false,
+      activeCueIndex: -1,
 
       // 从全局设置获取的默认值
       volume: globalSettings.defaultVolume,
@@ -179,6 +180,7 @@ export class PlayerSettingsService {
       duration: 0,
       paused: true,
       isFullscreen: false,
+      activeCueIndex: -1,
 
       // 从数据库恢复的设置
       volume: dbData.volume,

--- a/src/renderer/src/services/PlayerSettingsSaver.ts
+++ b/src/renderer/src/services/PlayerSettingsSaver.ts
@@ -38,12 +38,19 @@ export class PlayerSettingsPersistenceService {
   private debounceTimer: NodeJS.Timeout | null = null
   private readonly debounceMs = 1200
 
+  // 用户跳转时暂时禁用自动保存的标志位
+  private isUserSeeking = false
+  private userSeekingTimer: NodeJS.Timeout | null = null
+  private currentVideoId: number | null = null
+
   attach(videoId: number) {
     this.detach()
     if (!videoId || videoId <= 0) {
       logger.warn('attach: 无效 videoId，跳过', { videoId })
       return
     }
+
+    this.currentVideoId = videoId
 
     // 订阅持久化切片变化（手动在回调内比较，避免类型不匹配问题）
     this.unsubscribe = usePlayerStore.subscribe((state, prevState) => {
@@ -77,7 +84,56 @@ export class PlayerSettingsPersistenceService {
       clearTimeout(this.debounceTimer)
       this.debounceTimer = null
     }
+    if (this.debounceCurrentTimeTimer) {
+      clearTimeout(this.debounceCurrentTimeTimer)
+      this.debounceCurrentTimeTimer = null
+    }
+    if (this.userSeekingTimer) {
+      clearTimeout(this.userSeekingTimer)
+      this.userSeekingTimer = null
+    }
     this.lastSaved = null
+    this.isUserSeeking = false
+    this.currentVideoId = null
+  }
+
+  /**
+   * 标记用户正在跳转，暂时禁用 currentTime 的自动保存
+   */
+  markUserSeeking() {
+    this.isUserSeeking = true
+
+    // 清除之前的定时器
+    if (this.userSeekingTimer) {
+      clearTimeout(this.userSeekingTimer)
+    }
+
+    // 1秒后恢复自动保存（比 debounceCurrentTimeMs 稍长一些）
+    this.userSeekingTimer = setTimeout(async () => {
+      this.isUserSeeking = false
+      this.userSeekingTimer = null
+
+      // 立即保存一次当前播放进度，确保用户跳转后的位置被记录
+      if (this.currentVideoId) {
+        try {
+          const currentTime = usePlayerStore.getState().currentTime
+          await window.api.db.videoLibrary.updatePlayProgress(this.currentVideoId, currentTime)
+          logger.debug('用户跳转状态已恢复，立即保存当前进度', {
+            videoId: this.currentVideoId,
+            currentTime
+          })
+        } catch (error) {
+          logger.error('用户跳转状态恢复时保存进度失败', {
+            videoId: this.currentVideoId,
+            error
+          })
+        }
+      }
+
+      logger.debug('用户跳转状态已恢复，重新启用进度自动保存')
+    }, 1000)
+
+    logger.debug('已标记用户跳转状态，暂时禁用进度自动保存')
   }
 
   private onSliceChanged(videoId: number, slice: PlayerSettings) {
@@ -100,6 +156,12 @@ export class PlayerSettingsPersistenceService {
   }
 
   private onCurrentTimeChanged(videoId: number, currentTime: number) {
+    // 如果用户正在跳转，跳过自动保存
+    if (this.isUserSeeking) {
+      logger.debug('用户正在跳转，跳过进度自动保存', { videoId, currentTime })
+      return
+    }
+
     if (this.debounceCurrentTimeTimer) clearTimeout(this.debounceCurrentTimeTimer)
     this.debounceCurrentTimeTimer = setTimeout(async () => {
       try {

--- a/src/renderer/src/state/stores/player.store.ts
+++ b/src/renderer/src/state/stores/player.store.ts
@@ -40,6 +40,7 @@ export interface PlayerState {
   paused: boolean
   volume: number // 0–1
   muted: boolean
+  activeCueIndex: number // 当前活跃的字幕索引，-1 表示没有活跃字幕
 
   /** 播放速度 */
   playbackRate: number
@@ -100,6 +101,7 @@ export interface PlayerActions {
   setVolume: (v: number) => void // 引擎专用：通过 orchestrator.requestSetVolume() 调用
   setMuted: (m: boolean) => void // 引擎专用：通过 orchestrator.requestToggleMute() 调用
   setPlaybackRate: (r: number) => void // 引擎专用：通过 orchestrator.requestSetPlaybackRate() 调用
+  setActiveCueIndex: (index: number) => void // 引擎专用：由 orchestrator 字幕策略自动设置
 
   // === 常用速度控制 ===
   // 组件可调用：用户设置
@@ -150,6 +152,7 @@ const initialState: PlayerState = {
   paused: true,
   volume: 1,
   muted: false,
+  activeCueIndex: -1,
   playbackRate: 1,
   favoriteRates: [1.0], // 默认常用速度
   currentFavoriteIndex: 1, // 默认选择 1.0x
@@ -218,6 +221,7 @@ const createPlayerStore: StateCreator<PlayerStore, [['zustand/immer', never]], [
   setMuted: (m) => set((s: Draft<PlayerStore>) => void (s.muted = !!m)),
   setPlaybackRate: (r) =>
     set((s: Draft<PlayerStore>) => void (s.playbackRate = Math.max(0.25, Math.min(3, r)))),
+  setActiveCueIndex: (index) => set((s: Draft<PlayerStore>) => void (s.activeCueIndex = index)),
   setFullscreen: (f) => set((s: Draft<PlayerStore>) => void (s.isFullscreen = !!f)),
 
   // 常用速度控制


### PR DESCRIPTION
## Summary
- Fixes subtitle overlay not updating immediately during pause/seek operations
- Adds immediate store state synchronization in PlayerOrchestrator
- Implements UserSeeking state management to prevent auto-save conflicts

## Problem Solved
Previously, when users paused or sought through the video, the subtitle overlay would have a noticeable delay before updating to show the correct subtitle for the new time position. This created a poor user experience where the displayed subtitle didn't match the current video frame.

## Technical Changes
- **PlayerOrchestrator**: Added immediate `setCurrentTime()` calls during `seek()` and `jumpToCue()` operations
- **PlayerSettingsSaver**: Implemented `markUserSeeking()` mechanism to temporarily disable auto-save during user-initiated time changes
- **State Consistency**: Ensured UI components receive immediate state updates while maintaining data persistence integrity

## Test Plan
- [x] Verify subtitle overlay updates immediately when seeking
- [x] Confirm pause/resume shows correct subtitle instantly
- [x] Test jump-to-subtitle-cue functionality responds immediately
- [x] Validate auto-save still works after user interaction completes
- [x] Check no infinite update loops or state conflicts occur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can now expose and control the active subtitle cue (active cue index).

* **Improvements**
  * Timeline and subtitles jump immediately on user-initiated seeks for smoother feedback.
  * Subtitle sync is briefly locked after a user seek to prevent jarring autosync.
  * Subtitles now appear up to 2s before start to tolerate seek delays.
  * Stable subtitle objects reduce flicker and unnecessary re-renders.
  * Media seeking behavior refined for more accurate internal timing.

* **UI**
  * Video error modal now unmounts its content when hidden.

* **Performance**
  * Automatic progress saving is paused during seeks and an immediate save occurs after seeking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->