### PR TITLE
remove: subtitle display mode keyboard shortcuts

### DIFF
--- a/src/renderer/src/i18n/label.ts
+++ b/src/renderer/src/i18n/label.ts
@@ -176,10 +176,6 @@ const shortcutKeys = [
   'toggle_subtitle_panel',
   'playback_rate_next',
   'playback_rate_prev',
-  'subtitle_mode_none',
-  'subtitle_mode_original',
-  'subtitle_mode_translated',
-  'subtitle_mode_bilingual',
   'copy_subtitle'
 ] as const
 

--- a/src/renderer/src/infrastructure/constants/shortcuts.const.ts
+++ b/src/renderer/src/infrastructure/constants/shortcuts.const.ts
@@ -83,34 +83,6 @@ export const DEFAULT_SHORTCUTS: Shortcut[] = [
     system: true
   },
   {
-    key: 'subtitle_mode_none',
-    shortcut: ['CommandOrControl', '1'],
-    editable: true,
-    enabled: true,
-    system: false
-  },
-  {
-    key: 'subtitle_mode_original',
-    shortcut: ['CommandOrControl', '2'],
-    editable: true,
-    enabled: true,
-    system: false
-  },
-  {
-    key: 'subtitle_mode_translated',
-    shortcut: ['CommandOrControl', '3'],
-    editable: true,
-    enabled: true,
-    system: false
-  },
-  {
-    key: 'subtitle_mode_bilingual',
-    shortcut: ['CommandOrControl', '4'],
-    editable: true,
-    enabled: true,
-    system: false
-  },
-  {
     key: 'toggle_subtitle_panel',
     shortcut: ['CommandOrControl', 'BracketRight'],
     editable: true,

--- a/src/renderer/src/pages/player/hooks/usePlayerShortcuts.ts
+++ b/src/renderer/src/pages/player/hooks/usePlayerShortcuts.ts
@@ -32,7 +32,7 @@ const logger = loggerService.withContext('TransportBar')
 export function usePlayerShortcuts() {
   const { t } = useTranslation()
   const cmd = usePlayerCommands()
-  const { setDisplayMode, currentSubtitle } = useSubtitleOverlay()
+  const { currentSubtitle } = useSubtitleOverlay()
   const { toggleSubtitlePanel, cycleFavoriteRateNext, cycleFavoriteRatePrev } = usePlayerStore()
   const displayMode = usePlayerStore((s) => s.subtitleOverlay.displayMode)
 
@@ -131,27 +131,6 @@ export function usePlayerShortcuts() {
   // 单句循环
   useShortcut('single_loop', () => {
     cmd.toggleLoopEnabled()
-  })
-
-  // 字幕显示模式切换
-  useShortcut('subtitle_mode_none', () => {
-    setDisplayMode(SubtitleDisplayMode.NONE)
-    logger.info('字幕显示模式切换: 隐藏')
-  })
-
-  useShortcut('subtitle_mode_original', () => {
-    setDisplayMode(SubtitleDisplayMode.ORIGINAL)
-    logger.info('字幕显示模式切换: 仅原文')
-  })
-
-  useShortcut('subtitle_mode_translated', () => {
-    setDisplayMode(SubtitleDisplayMode.TRANSLATED)
-    logger.info('字幕显示模式切换: 仅译文')
-  })
-
-  useShortcut('subtitle_mode_bilingual', () => {
-    setDisplayMode(SubtitleDisplayMode.BILINGUAL)
-    logger.info('字幕显示模式切换: 双语显示')
   })
 
   // 字幕面板切换


### PR DESCRIPTION
## Summary

Remove all keyboard shortcuts for subtitle display modes to simplify the shortcut system.

## Changes

- **Removed shortcuts:**
  - `subtitle_mode_none` (Cmd/Ctrl+1) - Hide subtitles
  - `subtitle_mode_original` (Cmd/Ctrl+2) - Show original text only
  - `subtitle_mode_translated` (Cmd/Ctrl+3) - Show translated text only  
  - `subtitle_mode_bilingual` (Cmd/Ctrl+4) - Show bilingual display

- **Code changes:**
  - Remove shortcut configurations from `DEFAULT_SHORTCUTS` constant
  - Remove shortcut handlers from `usePlayerShortcuts` hook
  - Remove i18n label references from shortcut keys array
  - Clean up unused `setDisplayMode` import
  - Fix code formatting

## Impact

- Users can still change subtitle display modes through the UI interface
- Simplifies the keyboard shortcut system
- No functional loss as UI controls remain available

## Test plan

- [x] TypeScript compilation passes
- [x] ESLint checks pass  
- [x] Verified no remaining references to removed shortcuts
- [x] Application builds successfully