### PR TITLE
feat: add Windows ARM64 architecture support

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -60,9 +60,11 @@ win:
     - target: nsis
       arch:
         - x64
+        - arm64
     - target: portable
       arch:
         - x64
+        - arm64
   signtoolOptions:
     sign: scripts/win-sign.js
   verifyUpdateCodeSignature: false


### PR DESCRIPTION
## Summary

- Add ARM64 architecture support for Windows builds (both NSIS and Portable targets)
- Align Windows build configuration with existing macOS and Linux ARM64 support
- Enable native ARM64 package generation for Windows on ARM devices

## Changes Made

### Configuration Updates
- **electron-builder.yml**: Added `arm64` to Windows NSIS and Portable target architectures
- Maintains existing `x64` support while adding ARM64 compatibility

### Build Target Support
- **Windows NSIS**: Now supports both x64 and arm64
- **Windows Portable**: Now supports both x64 and arm64
- **Cross-platform consistency**: All platforms (Windows, macOS, Linux) now support both x64 and arm64

## Test Plan

- [x] Configuration file syntax validation passes
- [x] Verified all platform targets include ARM64 support
- [x] Existing build scripts (`build:win:arm64`) remain functional
- [ ] Test local ARM64 build (requires ARM64 Windows environment)
- [ ] Validate CI/CD pipeline generates ARM64 artifacts

## Technical Details

The change leverages the existing build infrastructure and package.json scripts. The GitHub Actions workflow will automatically build ARM64 packages when this configuration is merged, as it uses `electron-builder --win` which respects all architectures defined in the configuration.

## Benefits

- **Native Performance**: ARM64 Windows users get native performance instead of x64 emulation
- **Better Compatibility**: Improved compatibility with Windows on ARM devices
- **Future-Proofing**: Prepares for growing ARM64 Windows ecosystem
- **Consistent Experience**: Aligns Windows builds with macOS Apple Silicon support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added official Windows ARM64 support. Installers are now available for both x64 and ARM64 architectures, including NSIS and Portable formats. This enables installation on ARM-based Windows devices and broadens compatibility without changing existing x64 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->