### PR TITLE
feat: integrate Sentry error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 BASE_URL="https://api.openai.com/v1"          # Optional: For OpenAI models, if using a custom base URL.
 API_KEY="your_api_key_here"                  # Required: Your OpenAI API key.
+VITE_SENTRY_DSN=""                           # Optional: Sentry DSN for error tracking.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@remotion/media-parser": "^4.0.344",
+    "@sentry/electron": "^5.5.0",
     "antd": "^5.27.3",
     "better-sqlite3": "^12.2.0",
     "dompurify": "^3.2.6",

--- a/packages/shared/types/sentry.d.ts
+++ b/packages/shared/types/sentry.d.ts
@@ -1,0 +1,7 @@
+declare module '@sentry/electron/main' {
+  export function init(options?: any): void
+}
+
+declare module '@sentry/electron/renderer' {
+  export function init(options?: any): void
+}

--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -5,6 +5,15 @@ import path from 'path'
 
 import { initAppDataDir } from './utils/init'
 
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN
+if (sentryDsn) {
+  import('@sentry/electron/main')
+    .then(({ init }) =>
+      init({ dsn: sentryDsn, release: app.getVersion(), environment: import.meta.env.MODE })
+    )
+    .catch(() => {})
+}
+
 app.isPackaged && initAppDataDir()
 
 // 在主进程中复制 appData 中某些一直被占用的文件

--- a/src/main/env.d.ts
+++ b/src/main/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   VITE_MAIN_BUNDLE_ID: string
+  VITE_SENTRY_DSN?: string
 }
 
 interface ImportMeta {

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -7,6 +7,7 @@ import { NavigateFunction } from 'react-router-dom'
 
 interface ImportMetaEnv {
   VITE_RENDERER_INTEGRATED_MODEL: string
+  VITE_SENTRY_DSN?: string
 }
 
 interface ImportMeta {

--- a/src/renderer/src/init.ts
+++ b/src/renderer/src/init.ts
@@ -1,3 +1,10 @@
 import { loggerService } from './services/Logger'
 
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN
+if (sentryDsn) {
+  import('@sentry/electron/renderer')
+    .then(({ init }) => init({ dsn: sentryDsn, environment: import.meta.env.MODE }))
+    .catch(() => {})
+}
+
 loggerService.initWindowSource('mainWindow')


### PR DESCRIPTION
## Summary
- add Sentry dependency and env variables
- initialize Sentry in Electron main and renderer processes
- stub Sentry modules for type safety

## Testing
- `pnpm lint` *(warn: React hook missing dependency)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c685766bc08331af2185039a76dd14