### PR TITLE
fix(dictionary): support pronunciation extraction without UK/US distinction

### DIFF
--- a/src/main/services/DictionaryService.ts
+++ b/src/main/services/DictionaryService.ts
@@ -431,18 +431,14 @@ class DictionaryService {
   }): string | undefined => {
     try {
       // 验证必要参数
-      if (!params.langid || !params.voicename || !params.txt) {
+      if (!params.langid || !params.txt) {
         logger.debug('音频URL构建失败: 缺少必要参数', { params })
         return undefined
       }
 
       // 构建欧陆词典音频API的URL
       const audioApiUrl = 'https://api.frdic.com/api/v2/speech/speakweb'
-      const audioParams = new URLSearchParams({
-        langid: params.langid,
-        voicename: params.voicename,
-        txt: params.txt // txt 参数已经是编码后的
-      })
+      const audioParams = new URLSearchParams(params)
 
       const audioUrl = `${audioApiUrl}?${audioParams.toString()}`
 

--- a/src/renderer/src/infrastructure/types/dictionary.ts
+++ b/src/renderer/src/infrastructure/types/dictionary.ts
@@ -7,7 +7,7 @@ export interface DictionaryDefinition {
 
 // 发音信息
 export interface PronunciationInfo {
-  type: 'uk' | 'us' // 英式或美式发音
+  type: 'uk' | 'us' | null // 英式、美式发音或未知
   phonetic: string // 音标
   audioUrl?: string // 音频链接
   voiceParams?: string // 原始的语音参数

--- a/src/renderer/src/pages/player/components/DictionaryPopover.tsx
+++ b/src/renderer/src/pages/player/components/DictionaryPopover.tsx
@@ -157,37 +157,27 @@ export const DictionaryPopover = memo(function DictionaryPopover({
         {/* 显示详细发音信息 */}
         {data.pronunciations && data.pronunciations.length > 0 && (
           <PronunciationContainer>
-            {data.pronunciations.map((pronunciation, idx) => {
-              const getTypeLabel = (type: 'uk' | 'us' | null) => {
-                if (type === 'uk') return '英'
-                if (type === 'us') return '美'
-                return '通用' // 当类型未知时显示"通用"
-              }
-
-              const getTypeTitle = (type: 'uk' | 'us' | null) => {
-                if (type === 'uk') return '英式'
-                if (type === 'us') return '美式'
-                return '通用' // 当类型未知时显示"通用"
-              }
-
-              return (
-                <PronunciationGroup key={idx}>
-                  <PronunciationLabel>{getTypeLabel(pronunciation.type)}</PronunciationLabel>
-                  <PhoneticText>{pronunciation.phonetic}</PhoneticText>
-                  <PronunciationButton
-                    type="text"
-                    size="small"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      handlePronunciation(data.word, pronunciation.type || 'unknown', pronunciation)
-                    }}
-                    title={`${getTypeTitle(pronunciation.type)}发音: ${pronunciation.phonetic}`}
-                  >
-                    <Volume2 size={12} />
-                  </PronunciationButton>
-                </PronunciationGroup>
-              )
-            })}
+            {data.pronunciations.map((pronunciation, idx) => (
+              <PronunciationGroup key={idx}>
+                {pronunciation.type && (
+                  <PronunciationLabel>
+                    {pronunciation.type === 'uk' ? '英' : '美'}
+                  </PronunciationLabel>
+                )}
+                <PhoneticText>{pronunciation.phonetic}</PhoneticText>
+                <PronunciationButton
+                  type="text"
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handlePronunciation(data.word, pronunciation.type || 'uk', pronunciation)
+                  }}
+                  title={`${pronunciation.type === 'uk' ? '英式' : '美式'}发音: ${pronunciation.phonetic}`}
+                >
+                  <Volume2 size={12} />
+                </PronunciationButton>
+              </PronunciationGroup>
+            ))}
           </PronunciationContainer>
         )}
 

--- a/src/renderer/src/pages/player/components/DictionaryPopover.tsx
+++ b/src/renderer/src/pages/player/components/DictionaryPopover.tsx
@@ -157,23 +157,37 @@ export const DictionaryPopover = memo(function DictionaryPopover({
         {/* 显示详细发音信息 */}
         {data.pronunciations && data.pronunciations.length > 0 && (
           <PronunciationContainer>
-            {data.pronunciations.map((pronunciation, idx) => (
-              <PronunciationGroup key={idx}>
-                <PronunciationLabel>{pronunciation.type === 'uk' ? '英' : '美'}</PronunciationLabel>
-                <PhoneticText>{pronunciation.phonetic}</PhoneticText>
-                <PronunciationButton
-                  type="text"
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    handlePronunciation(data.word, pronunciation.type, pronunciation)
-                  }}
-                  title={`${pronunciation.type === 'uk' ? '英式' : '美式'}发音: ${pronunciation.phonetic}`}
-                >
-                  <Volume2 size={12} />
-                </PronunciationButton>
-              </PronunciationGroup>
-            ))}
+            {data.pronunciations.map((pronunciation, idx) => {
+              const getTypeLabel = (type: 'uk' | 'us' | null) => {
+                if (type === 'uk') return '英'
+                if (type === 'us') return '美'
+                return '通用' // 当类型未知时显示"通用"
+              }
+
+              const getTypeTitle = (type: 'uk' | 'us' | null) => {
+                if (type === 'uk') return '英式'
+                if (type === 'us') return '美式'
+                return '通用' // 当类型未知时显示"通用"
+              }
+
+              return (
+                <PronunciationGroup key={idx}>
+                  <PronunciationLabel>{getTypeLabel(pronunciation.type)}</PronunciationLabel>
+                  <PhoneticText>{pronunciation.phonetic}</PhoneticText>
+                  <PronunciationButton
+                    type="text"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handlePronunciation(data.word, pronunciation.type || 'unknown', pronunciation)
+                    }}
+                    title={`${getTypeTitle(pronunciation.type)}发音: ${pronunciation.phonetic}`}
+                  >
+                    <Volume2 size={12} />
+                  </PronunciationButton>
+                </PronunciationGroup>
+              )
+            })}
           </PronunciationContainer>
         )}
 


### PR DESCRIPTION
## Summary

修复词典服务中发音提取的问题，支持没有明确区分英美音的发音信息提取。

### 🔧 Changes Made

- **类型定义更新**: 将 `PronunciationInfo.type` 从 `'uk' | 'us'` 修改为 `'uk' | 'us' | null`，支持未知发音类型
- **发音解析逻辑增强**: 
  - 方式1: 继续支持有明确英/美音标识的发音（向后兼容）
  - 方式2: 新增支持没有 `phontype` 标识但有音频的发音
  - 方式3: 支持纯音标提取（没有音频的情况）
- **UI 组件适配**: 在 `DictionaryPopover` 中正确处理 `type` 为 `null` 的情况，显示"通用"标签
- **测试覆盖**: 添加针对 crystal 类型案例的综合测试

### 🐛 Fixes

解决了类似 crystal 这种情况下的发音提取问题：
```html
<a href="javascript:void(0);" title="发音" class="voice-js voice-button voice-button-en" data-rel="langid=en&amp;txt=QYNY3J5c3RhbHM%3d" data-volume="0.5">
  <span class="Phonitic">/'krɪstl/</span>
</a>
```

现在可以：
- ✅ 正确提取音标 `/'krɪstl/`
- ✅ 设置 `type` 为 `null`（未知类型）
- ✅ 保存语音参数用于可能的音频播放
- ✅ UI 显示"通用"而非英/美标识
- ✅ 保持与原有英/美音格式的兼容性

### 🧪 Test Plan

- [x] 所有现有测试通过
- [x] 新增的 crystal 类型发音提取测试通过
- [x] 类型检查通过
- [x] UI 组件正确显示未知类型发音

### 📝 Notes

这个修复确保了系统能够处理欧陆词典中各种不同的发音信息格式，包括那些没有明确区分英美音的情况，提高了发音信息提取的覆盖率和健壮性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved pronunciation parsing to handle entries with unknown or missing UK/US type and more tolerant audio lookup.
- UI
  - Pronunciation label is hidden for unknown types; playback still works (defaults to a sensible accent when type is missing).
- Bug Fixes
  - More robust extraction of phonetics and audio across varied HTML structures.
- Tests
  - Added tests for single-entry pronunciations and scenarios with missing or non‑differentiated accent information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->