### PR TITLE
fix(player): resolve focus loss after dictionary popup interaction

### DIFF
--- a/src/renderer/src/pages/player/components/DictionaryPopover.tsx
+++ b/src/renderer/src/pages/player/components/DictionaryPopover.tsx
@@ -170,7 +170,7 @@ export const DictionaryPopover = memo(function DictionaryPopover({
                   size="small"
                   onClick={(e) => {
                     e.stopPropagation()
-                    handlePronunciation(data.word, pronunciation.type, pronunciation)
+                    handlePronunciation(data.word, pronunciation.type || 'uk', pronunciation)
                     // 阻止按钮获得焦点，避免影响播放器快捷键
                     ;(e.target as HTMLElement).blur()
                   }}

--- a/src/renderer/src/pages/player/components/DictionaryPopover.tsx
+++ b/src/renderer/src/pages/player/components/DictionaryPopover.tsx
@@ -167,6 +167,12 @@ export const DictionaryPopover = memo(function DictionaryPopover({
                   onClick={(e) => {
                     e.stopPropagation()
                     handlePronunciation(data.word, pronunciation.type, pronunciation)
+                    // 阻止按钮获得焦点，避免影响播放器快捷键
+                    ;(e.target as HTMLElement).blur()
+                  }}
+                  onMouseDown={(e) => {
+                    // 阻止按钮在点击时获得焦点
+                    e.preventDefault()
                   }}
                   title={`${pronunciation.type === 'uk' ? '英式' : '美式'}发音: ${pronunciation.phonetic}`}
                 >

--- a/src/renderer/src/pages/player/components/SubtitleContent.tsx
+++ b/src/renderer/src/pages/player/components/SubtitleContent.tsx
@@ -198,6 +198,24 @@ export const SubtitleContent = memo(function SubtitleContent({
         error: null
       }
     }))
+
+    // 词典弹窗关闭后，将焦点恢复到容器元素，确保快捷键能正常工作
+    setTimeout(() => {
+      if (containerRef.current) {
+        // 找到可以获得焦点的播放器元素
+        const videoSurface = document.querySelector('[data-testid="video-surface"]') as HTMLElement
+        const subtitleOverlay = document.querySelector(
+          '[data-testid="subtitle-overlay"]'
+        ) as HTMLElement
+
+        // 优先将焦点给到视频表面，其次是字幕覆盖层
+        if (videoSurface) {
+          videoSurface.focus()
+        } else if (subtitleOverlay) {
+          subtitleOverlay.focus()
+        }
+      }
+    }, 100) // 延迟确保弹窗完全关闭后再恢复焦点
   }, [])
 
   // === 划词选中处理 ===


### PR DESCRIPTION
## Summary

修复了点击查词后焦点丢失导致播放器快捷键失效的问题。

- 修复点击词典弹窗中的发音按钮后，空格键等播放器快捷键失效的问题
- 添加了双重焦点管理机制：阻止按钮获得焦点 + 弹窗关闭时自动恢复焦点
- 保持查词和发音功能的完整性，不影响用户的学习体验
- 提升了播放器交互的流畅性和用户体验

## Test plan

- [ ] 测试基本查词功能：点击单词能正常弹出词典
- [ ] 测试发音功能：点击发音按钮能正常播放发音
- [ ] 测试焦点修复：点击发音按钮后，空格键仍能正常播放/暂停
- [ ] 测试弹窗关闭：词典弹窗关闭后焦点能正确回归
- [ ] 测试其他快捷键：确认其他播放器快捷键（音量、跳转等）正常工作
- [ ] 测试不同主题：确认在浅色和深色主题下修复都生效
- [ ] 测试无障碍功能：确认修复不影响键盘导航和屏幕阅读器

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pronunciation button no longer retains focus: clicks blur the button and mouse-down won’t grant focus, preventing interruptions to player shortcuts.
  * Restored focus to the player after closing the dictionary popover: focus returns to the video surface (falls back to subtitle overlay) after a short delay.
  * Improved keyboard accessibility and reduced unintended focus shifts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->