### PR TITLE
feat(updater): integrate China-specific feed URLs for better update experience

### DIFF
--- a/packages/shared/config/constant.ts
+++ b/packages/shared/config/constant.ts
@@ -24,9 +24,12 @@ export const GB = 1024 * MB
 export const defaultLanguage = 'zh-CN'
 
 export enum FeedUrl {
-  PRODUCTION = 'https://releases.echoplayer.cc',
+  PRODUCTION = 'http://release.echoplayer.z2blog.com/api/releases',
   GITHUB_LATEST = 'https://github.com/mkdir700/EchoPlayer/releases/latest/download',
-  PRERELEASE_LOWEST = 'https://github.com/mkdir700/EchoPlayer/releases/download/v0.1.0'
+  PRERELEASE_LOWEST = 'https://github.com/mkdir700/EchoPlayer/releases/download/v0.1.0',
+  // 中国用户特有的预发布渠道 feed URL
+  CN_BETA = 'http://release.echoplayer.z2blog.com/api/beta/releases',
+  CN_ALPHA = 'http://release.echoplayer.z2blog.com/api/alpha/releases'
 }
 
 export enum UpgradeChannel {


### PR DESCRIPTION
## Summary

• 为中国用户集成专用的feed URL，提供更好的更新体验
• 将PRODUCTION URL设置为中国镜像地址
• 简化更新器逻辑，统一使用PRODUCTION URL处理稳定版本

## Changes

### Feed URL Configuration
- **PRODUCTION**: 更新为中国镜像 `http://release.echoplayer.z2blog.com/api/releases`
- **CN_ALPHA**: 新增Alpha版本中国镜像 `http://release.echoplayer.z2blog.com/api/alpha/releases`  
- **CN_BETA**: 新增Beta版本中国镜像 `http://release.echoplayer.z2blog.com/api/beta/releases`

### AppUpdater Logic Updates
- 所有用户的稳定版更新统一使用PRODUCTION URL（中国镜像）
- 中国用户的预发布版本使用对应的中国镜像URL
- 非中国用户的测试模式继续使用GitHub URL
- 优化日志信息，区分中国镜像使用情况

## Benefits

- **更快的更新速度**: 中国用户使用本地化镜像服务器
- **更好的可靠性**: 减少网络连接问题导致的更新失败
- **统一的架构**: 简化了URL配置和逻辑处理
- **向后兼容**: 非中国用户体验保持不变

## Test plan

- [ ] 测试中国IP用户的稳定版更新
- [ ] 测试中国IP用户的Alpha/Beta版本更新  
- [ ] 测试非中国IP用户的更新功能
- [ ] 验证日志信息正确显示镜像使用情况

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Region-aware updates: the app now auto-selects the optimal update source based on your location.
  * Improved update reliability and speed for users in mainland China with localized feeds for Latest, Beta, and Alpha channels.
  * Added China-specific pre-release channels to widen availability of early builds for CN users.
* **Chores**
  * Updated default production update URL to improve service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->