### PR TITLE
fix(player): resolve spacebar shortcut not working after clicking to pause

### DIFF
--- a/src/renderer/src/pages/player/components/VideoSurface.tsx
+++ b/src/renderer/src/pages/player/components/VideoSurface.tsx
@@ -208,12 +208,6 @@ function VideoSurface({ src, onLoadedMetadata, onError }: VideoSurfaceProps) {
       data-testid="video-surface"
       onClick={handleSurfaceClick}
       tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          handleSurfaceClick()
-        }
-      }}
     >
       <StyledVideo
         ref={handleVideoRef}

--- a/src/renderer/src/pages/player/hooks/usePlayerShortcuts.ts
+++ b/src/renderer/src/pages/player/hooks/usePlayerShortcuts.ts
@@ -97,8 +97,14 @@ export function usePlayerShortcuts() {
   }, [currentSubtitle, displayMode, t])
 
   useShortcut('play_pause', () => {
+    logger.debug('空格键快捷键触发', {
+      activeElement: document.activeElement?.tagName,
+      activeElementClass: document.activeElement?.className,
+      activeElementId: document.activeElement?.id,
+      timestamp: Date.now()
+    })
     cmd.playPause()
-    logger.info('Shortcut play_pause')
+    logger.info('Shortcut play_pause executed')
   })
 
   // 重播当前字幕


### PR DESCRIPTION
## Summary

Fixes issue where clicking VideoSurface to pause the video would prevent the spacebar shortcut from resuming playback. Users had to move focus to other elements (like control bar) for the spacebar shortcut to work again.

## Root Cause

- VideoSurface component had duplicate keyboard event handling via `onKeyDown` 
- This handler intercepted space key events and called `e.preventDefault()`
- Prevented global shortcut system from receiving the event when focus was on VideoSurface

## Changes

- ✅ Remove duplicate `onKeyDown` handler from VideoSurface component
- ✅ Add enhanced debug logging to track shortcut triggers and focus state
- ✅ Ensure all keyboard shortcuts are handled consistently through global shortcut system

## Test Plan

- [x] Click VideoSurface to pause, then immediately press spacebar → should resume playback
- [x] Click VideoSurface to play, then press spacebar → should pause  
- [x] Use control bar buttons with spacebar shortcuts → should work consistently
- [x] Verify focus management and accessibility features still work

## Technical Details

The fix maintains:
- Click interaction on VideoSurface (`onClick` handler)
- Accessibility support (`tabIndex={0}`)
- Unified shortcut handling through `usePlayerShortcuts`

Removes:
- Redundant keyboard event processing that conflicted with global shortcuts
- Event propagation blocking that prevented consistent behavior