### PR TITLE
fix: remove green glow effect from progress bar

### DIFF
--- a/src/renderer/src/infrastructure/styles/theme.ts
+++ b/src/renderer/src/infrastructure/styles/theme.ts
@@ -296,8 +296,8 @@ export const COMPONENT_TOKENS = {
     // 主题色阴影系统
     HANDLE_SHADOW: '0 2px 8px rgba(0, 0, 0, 0.25)', // 手柄阴影
     HANDLE_SHADOW_HOVER: '0 4px 16px rgba(0, 0, 0, 0.3)', // 悬停时手柄阴影
-    PROGRESS_GLOW: '0 0 8px rgba(0, 185, 107, 0.4)', // 进度条光晕效果（绿色）
-    PROGRESS_GLOW_HOVER: '0 0 12px rgba(0, 185, 107, 0.6)', // 悬停时光晕
+    PROGRESS_GLOW: 'none', // 移除进度条光晕效果
+    PROGRESS_GLOW_HOVER: 'none', // 移除悬停时光晕
 
     // 动画系统 - Netflix 风格的流畅过渡
     TRANSITION_FAST: '0.15s cubic-bezier(0.4, 0, 0.2, 1)', // 快速过渡

--- a/src/renderer/src/infrastructure/styles/theme.ts
+++ b/src/renderer/src/infrastructure/styles/theme.ts
@@ -274,14 +274,14 @@ export const COMPONENT_TOKENS = {
     BUFFER_HEIGHT: 2, // 缓冲进度高度
     BUFFER_OPACITY: 0.4, // 缓冲进度透明度
 
-    // Netflix 红色配色系统
-    NETFLIX_RED: '#e50914', // Netflix 标志性红色
-    NETFLIX_RED_HOVER: '#f40612', // 悬停时的亮红色
-    NETFLIX_RED_ACTIVE: '#d40913', // 激活时的深红色
+    // 应用主题色系统
+    THEME_PRIMARY: 'var(--color-primary, #00b96b)', // 应用主题色
+    THEME_PRIMARY_SOFT: 'var(--color-primary-soft, #00b96b99)', // 半透明主题色
+    THEME_PRIMARY_MUTE: 'var(--color-primary-mute, #00b96b33)', // 静音主题色
 
     // 渐变系统
-    PROGRESS_GRADIENT: 'linear-gradient(90deg, #e50914 0%, #f40612 100%)', // 进度条渐变
-    HANDLE_GRADIENT: 'radial-gradient(circle, #ffffff 0%, #f8f8f8 70%, #e0e0e0 100%)', // 手柄渐变
+    PROGRESS_GRADIENT: 'var(--color-primary, #00b96b)', // 使用纯色而非渐变，更简洁
+    HANDLE_GRADIENT: 'radial-gradient(circle, #ffffff 0%, #f8f8f8 70%, #e0e0e0 100%)', // 手柄渐变保持白色
 
     // 透明度系统
     RAIL_OPACITY_HIDDEN: 0.1, // 隐藏状态轨道透明度
@@ -293,11 +293,11 @@ export const COMPONENT_TOKENS = {
     HANDLE_OPACITY_HOVER: 0.95, // 悬停时显示
     HANDLE_OPACITY_ACTIVE: 1, // 激活时完全显示
 
-    // Netflix 风格阴影系统
+    // 主题色阴影系统
     HANDLE_SHADOW: '0 2px 8px rgba(0, 0, 0, 0.25)', // 手柄阴影
     HANDLE_SHADOW_HOVER: '0 4px 16px rgba(0, 0, 0, 0.3)', // 悬停时手柄阴影
-    PROGRESS_GLOW: '0 0 8px rgba(229, 9, 20, 0.4)', // 进度条光晕效果
-    PROGRESS_GLOW_HOVER: '0 0 12px rgba(229, 9, 20, 0.6)', // 悬停时光晕
+    PROGRESS_GLOW: '0 0 8px rgba(0, 185, 107, 0.4)', // 进度条光晕效果（绿色）
+    PROGRESS_GLOW_HOVER: '0 0 12px rgba(0, 185, 107, 0.6)', // 悬停时光晕
 
     // 动画系统 - Netflix 风格的流畅过渡
     TRANSITION_FAST: '0.15s cubic-bezier(0.4, 0, 0.2, 1)', // 快速过渡

--- a/src/renderer/src/infrastructure/styles/theme.ts
+++ b/src/renderer/src/infrastructure/styles/theme.ts
@@ -257,62 +257,79 @@ export const COMPONENT_TOKENS = {
     FADE_IN_DURATION: ANIMATION_DURATION.SLOW
   },
 
-  // 进度条组件
+  // Netflix 风格进度条组件
   PROGRESS_BAR: {
-    // 尺寸系统
-    TRACK_HEIGHT_BASE: 4, // 基础轨道高度
-    TRACK_HEIGHT_HOVER: 6, // 悬停轨道高度
-    TRACK_HEIGHT_DRAG: 6, // 拖动轨道高度
+    // Netflix 风格尺寸系统 - 极简主义设计
+    TRACK_HEIGHT_HIDDEN: 1, // 隐藏/默认状态极细轨道
+    TRACK_HEIGHT_BASE: 2, // 基础轨道高度
+    TRACK_HEIGHT_HOVER: 4, // 悬停时轨道高度
+    TRACK_HEIGHT_ACTIVE: 6, // 激活/拖拽时轨道高度
 
-    HANDLE_SIZE_BASE: 8, // 基础手柄尺寸
-    HANDLE_SIZE_HOVER: 12, // 悬停手柄尺寸
-    HANDLE_SIZE_DRAG: 14, // 拖动手柄尺寸
+    // Netflix 风格手柄系统
+    HANDLE_SIZE_BASE: 0, // 默认隐藏手柄
+    HANDLE_SIZE_HOVER: 14, // 悬停时手柄尺寸
+    HANDLE_SIZE_ACTIVE: 16, // 激活时手柄尺寸
 
-    // 边框系统
-    HANDLE_BORDER_BASE: 1, // 基础边框宽度
-    HANDLE_BORDER_HOVER: 1.5, // 悬停边框宽度
-    HANDLE_BORDER_DRAG: 2, // 拖动边框宽度
+    // 缓冲进度轨道
+    BUFFER_HEIGHT: 2, // 缓冲进度高度
+    BUFFER_OPACITY: 0.4, // 缓冲进度透明度
 
-    // 圆角系统
-    TRACK_BORDER_RADIUS: BORDER_RADIUS.SM / 2, // 3px
+    // Netflix 红色配色系统
+    NETFLIX_RED: '#e50914', // Netflix 标志性红色
+    NETFLIX_RED_HOVER: '#f40612', // 悬停时的亮红色
+    NETFLIX_RED_ACTIVE: '#d40913', // 激活时的深红色
+
+    // 渐变系统
+    PROGRESS_GRADIENT: 'linear-gradient(90deg, #e50914 0%, #f40612 100%)', // 进度条渐变
+    HANDLE_GRADIENT: 'radial-gradient(circle, #ffffff 0%, #f8f8f8 70%, #e0e0e0 100%)', // 手柄渐变
 
     // 透明度系统
-    HANDLE_GRADIENT_INNER: 0.9, // 内圈渐变透明度
-    HANDLE_GRADIENT_OUTER: 0.7, // 外圈渐变透明度
-    HANDLE_BORDER_ALPHA: 0.6, // 边框透明度
-    HANDLE_BORDER_ALPHA_HOVER: 0.8, // 悬停边框透明度
+    RAIL_OPACITY_HIDDEN: 0.1, // 隐藏状态轨道透明度
+    RAIL_OPACITY_BASE: 0.2, // 基础轨道透明度
+    RAIL_OPACITY_HOVER: 0.35, // 悬停轨道透明度
 
-    RAIL_OPACITY_BASE: 0.15, // 基础轨道透明度
-    RAIL_OPACITY_HOVER: 0.3, // 悬停轨道透明度
-    RAIL_OPACITY_DRAG: 0.4, // 拖动轨道透明度
+    // 手柄透明度
+    HANDLE_OPACITY_BASE: 0, // 默认隐藏
+    HANDLE_OPACITY_HOVER: 0.95, // 悬停时显示
+    HANDLE_OPACITY_ACTIVE: 1, // 激活时完全显示
 
-    // 阴影系统
-    HANDLE_SHADOW_BLUR_BASE: 4, // 基础光晕模糊半径
-    HANDLE_SHADOW_BLUR_HOVER: 8, // 悬停光晕模糊半径
-    HANDLE_SHADOW_BLUR_DRAG_1: 12, // 拖动光晕模糊半径1
-    HANDLE_SHADOW_BLUR_DRAG_2: 24, // 拖动光晕模糊半径2
+    // Netflix 风格阴影系统
+    HANDLE_SHADOW: '0 2px 8px rgba(0, 0, 0, 0.25)', // 手柄阴影
+    HANDLE_SHADOW_HOVER: '0 4px 16px rgba(0, 0, 0, 0.3)', // 悬停时手柄阴影
+    PROGRESS_GLOW: '0 0 8px rgba(229, 9, 20, 0.4)', // 进度条光晕效果
+    PROGRESS_GLOW_HOVER: '0 0 12px rgba(229, 9, 20, 0.6)', // 悬停时光晕
 
-    HANDLE_SHADOW_OFFSET: 2, // 阴影偏移
-    HANDLE_SHADOW_ALPHA_BASE: 0.4, // 基础阴影透明度
-    HANDLE_SHADOW_ALPHA_HOVER: 0.6, // 悬停阴影透明度
-    HANDLE_SHADOW_ALPHA_DRAG: 0.8, // 拖动阴影透明度
+    // 动画系统 - Netflix 风格的流畅过渡
+    TRANSITION_FAST: '0.15s cubic-bezier(0.4, 0, 0.2, 1)', // 快速过渡
+    TRANSITION_SMOOTH: '0.25s cubic-bezier(0.25, 0.1, 0.25, 1)', // 平滑过渡
+    TRANSITION_ELASTIC: '0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)', // 弹性过渡
 
-    TRACK_SHADOW_BLUR_HOVER: 8, // 轨道悬停光晕
-    TRACK_SHADOW_BLUR_DRAG: 16, // 轨道拖动光晕
+    // 智能显示系统
+    AUTO_HIDE_DELAY: 2000, // 自动隐藏延迟 (ms)
+    SHOW_ON_HOVER_DELAY: 0, // 悬停显示延迟
+    INTERACTION_AREA_HEIGHT: 20, // 交互区域高度
 
-    // 动画系统
-    TRANSITION_DURATION_BASE: ANIMATION_DURATION.MEDIUM, // 0.2s
-    TRANSITION_DURATION_SLOW: '0.25s', // 慢速动画
-    TRANSITION_EASING: EASING.STANDARD, // cubic-bezier(0.4, 0, 0.2, 1)
+    // 缩放系统 - 更精细的控制
+    HANDLE_SCALE_HIDDEN: 0, // 隐藏状态
+    HANDLE_SCALE_BASE: 0, // 基础状态
+    HANDLE_SCALE_HOVER: 1, // 悬停状态
+    HANDLE_SCALE_ACTIVE: 1.1, // 激活状态
 
-    // 缩放系统
-    HANDLE_SCALE_HIDDEN: 0, // 隐藏时缩放
-    HANDLE_SCALE_BASE: 0.8, // 基础缩放
-    HANDLE_SCALE_HOVER: 1, // 悬停缩放
-    HANDLE_SCALE_DRAG: 1.1, // 拖动缩放
+    // 边框和圆角
+    TRACK_BORDER_RADIUS: 2, // 轨道圆角
+    HANDLE_BORDER_RADIUS: '50%', // 手柄圆角 (圆形)
 
-    // 计算工具函数
-    calculateHandleOffset: (handleSize: number, trackSize: number) => -(handleSize - trackSize) / 2
+    // 预览缩略图区域 (预留)
+    PREVIEW_WIDTH: 160, // 预览缩略图宽度
+    PREVIEW_HEIGHT: 90, // 预览缩略图高度
+    PREVIEW_BORDER_RADIUS: 4, // 预览图圆角
+
+    // 时间显示优化
+    TIME_FONT_SIZE: 12, // 时间文字大小
+    TIME_OPACITY: 0.9, // 时间文字透明度
+
+    // 工具函数
+    calculateHandleOffset: (handleSize: number) => -handleSize / 2
   }
 } as const
 

--- a/src/renderer/src/pages/player/components/ProgressBar.tsx
+++ b/src/renderer/src/pages/player/components/ProgressBar.tsx
@@ -1,364 +1,345 @@
-import { useTheme } from '@renderer/contexts/theme.context'
 import { COMPONENT_TOKENS } from '@renderer/infrastructure/styles/theme'
 import { formatTime } from '@renderer/state/infrastructure/utils'
 import { usePlayerStore } from '@renderer/state/stores/player.store'
 import { PerformanceMonitor } from '@renderer/utils/PerformanceMonitor'
-import { Slider } from 'antd'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { usePlayerCommands } from '../hooks/usePlayerCommands'
 
-const formatProgress = (currentTime: number, duration: number): string => {
-  return `${formatTime(currentTime)} / ${formatTime(duration)}`
+const formatTimeOnly = (time: number): string => {
+  return formatTime(time)
 }
 
 function ProgressBar() {
   const currentTime = usePlayerStore((s) => s.currentTime)
   const duration = usePlayerStore((s) => s.duration)
   const { seekToUser } = usePlayerCommands()
-  const { token } = useTheme()
 
-  // 使用 ref 来跟踪是否是第一次 onChange（开始拖拽）
-  const isFirstChange = useRef(true)
-  const dragTimeoutRef = useRef<number | null>(null)
-
-  // 跟踪悬停和拖动状态
+  // Netflix 风格状态管理
   const [isHovering, setIsHovering] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
+  const [isVisible, setIsVisible] = useState(false)
+  const [previewTime, setPreviewTime] = useState<number | null>(null)
+  const [bufferProgress, setBufferProgress] = useState(0)
 
-  // 清理定时器（组件卸载）
+  // 引用管理
+  const progressBarRef = useRef<HTMLDivElement>(null)
+  const hideTimeoutRef = useRef<number | null>(null)
+  const dragStartRef = useRef(false)
+
+  // Netflix 风格自动隐藏逻辑
   useEffect(() => {
+    if (isHovering || isDragging) {
+      setIsVisible(true)
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current)
+      }
+    } else {
+      hideTimeoutRef.current = window.setTimeout(() => {
+        setIsVisible(false)
+      }, COMPONENT_TOKENS.PROGRESS_BAR.AUTO_HIDE_DELAY)
+    }
+
     return () => {
-      if (dragTimeoutRef.current) {
-        clearTimeout(dragTimeoutRef.current)
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current)
       }
     }
-  }, [])
+  }, [isHovering, isDragging])
+
+  // 模拟缓冲进度（实际项目中应从视频元素获取）
+  useEffect(() => {
+    if (duration && currentTime) {
+      // 简单模拟：缓冲进度稍微领先播放进度
+      const simulatedBuffer = Math.min((currentTime + 30) / duration, 1)
+      setBufferProgress(simulatedBuffer)
+    }
+  }, [currentTime, duration])
 
   const handleProgressChange = useCallback(
-    (value: number) => {
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!duration || !progressBarRef.current) return
+
       const m = new PerformanceMonitor('handleProgressChange')
+      const rect = progressBarRef.current.getBoundingClientRect()
+      const clickX = event.clientX - rect.left
+      const progress = Math.max(0, Math.min(1, clickX / rect.width))
+      const newTime = progress * duration
 
-      // 第一次改变时重置循环状态并设置拖动状态
-      if (isFirstChange.current) {
-        isFirstChange.current = false
-        setIsDragging(true)
-      }
-
-      // 清理之前的定时器
-      if (dragTimeoutRef.current) {
-        clearTimeout(dragTimeoutRef.current)
-      }
-
-      // 设置定时器，在拖拽停止后一段时间后重置状态
-      dragTimeoutRef.current = window.setTimeout(() => {
-        isFirstChange.current = true
-      }, 200)
-
-      // 使用用户跳转方法，自动管理循环禁用状态
-      seekToUser(Math.max(0, value))
-
+      seekToUser(newTime)
       m.finish()
     },
-    [seekToUser]
+    [duration, seekToUser]
   )
 
-  // 处理拖拽结束
-  const handleDragEnd = useCallback(() => {
-    // 重置拖拽状态
-    isFirstChange.current = true
-    setIsDragging(false)
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return // 只处理左键
 
-    // 清理定时器
-    if (dragTimeoutRef.current) {
-      clearTimeout(dragTimeoutRef.current)
-      dragTimeoutRef.current = null
-    }
-  }, [])
+      setIsDragging(true)
+      dragStartRef.current = true
+      handleProgressChange(event)
 
-  // 处理鼠标进入
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!duration || !progressBarRef.current || !dragStartRef.current) return
+
+        const rect = progressBarRef.current.getBoundingClientRect()
+        const clickX = e.clientX - rect.left
+        const progress = Math.max(0, Math.min(1, clickX / rect.width))
+        const newTime = progress * duration
+
+        seekToUser(newTime)
+      }
+
+      const handleMouseUp = () => {
+        setIsDragging(false)
+        dragStartRef.current = false
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+      }
+
+      document.addEventListener('mousemove', handleMouseMove)
+      document.addEventListener('mouseup', handleMouseUp)
+    },
+    [duration, seekToUser, handleProgressChange]
+  )
+
   const handleMouseEnter = useCallback(() => {
     setIsHovering(true)
   }, [])
 
-  // 处理鼠标离开
   const handleMouseLeave = useCallback(() => {
     setIsHovering(false)
+    setPreviewTime(null)
   }, [])
 
-  // Memoize tooltip配置避免每次渲染重建
-  const tooltipConfig = useMemo(
-    () => ({
-      formatter: (value?: number) => formatProgress(value ?? 0, duration ?? 0)
-    }),
-    [duration]
+  const handleMouseMove = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!duration || !progressBarRef.current || isDragging) return
+
+      const rect = progressBarRef.current.getBoundingClientRect()
+      const hoverX = event.clientX - rect.left
+      const progress = Math.max(0, Math.min(1, hoverX / rect.width))
+      const hoverTime = progress * duration
+
+      setPreviewTime(hoverTime)
+    },
+    [duration, isDragging]
   )
 
-  // 约束value值在有效范围内
-  const clampedValue = useMemo(
-    () => Math.min(Math.max(0, currentTime ?? 0), duration ?? 0),
-    [currentTime, duration]
-  )
+  // 计算当前进度百分比
+  const progressPercentage = useMemo(() => {
+    if (!duration || !currentTime) return 0
+    return Math.max(0, Math.min(100, (currentTime / duration) * 100))
+  }, [currentTime, duration])
+
+  // 计算缓冲进度百分比
+  const bufferPercentage = useMemo(() => {
+    return Math.max(0, Math.min(100, bufferProgress * 100))
+  }, [bufferProgress])
+
+  // 预览时间显示
+  const previewTimeDisplay = useMemo(() => {
+    return previewTime !== null ? formatTimeOnly(previewTime) : null
+  }, [previewTime])
 
   return (
-    <SliderWrapper onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-      <StyledSlider
-        min={0}
-        max={duration || 100}
-        value={clampedValue}
-        onChange={handleProgressChange}
-        onChangeComplete={handleDragEnd}
-        tooltip={tooltipConfig}
-        disabled={!duration}
-        aria-label="Progress"
-        $isHovering={isHovering}
-        $isDragging={isDragging}
-        $token={token}
-      />
-    </SliderWrapper>
+    <ProgressContainer
+      ref={progressBarRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onMouseMove={handleMouseMove}
+      onMouseDown={handleMouseDown}
+      $isVisible={isVisible}
+      $isHovering={isHovering}
+      $isDragging={isDragging}
+    >
+      {/* 缓冲进度条 */}
+      <BufferTrack $progress={bufferPercentage} />
+
+      {/* 主进度轨道 */}
+      <ProgressTrack />
+
+      {/* 已播放进度 */}
+      <ProgressFill $progress={progressPercentage} />
+
+      {/* 手柄 */}
+      <ProgressHandle $progress={progressPercentage} $isVisible={isHovering || isDragging} />
+
+      {/* 时间预览提示 */}
+      {previewTimeDisplay && isHovering && !isDragging && (
+        <TimePreview $show={true}>{previewTimeDisplay}</TimePreview>
+      )}
+    </ProgressContainer>
   )
 }
 
 export default ProgressBar
 
-// 包装容器处理鼠标事件
-const SliderWrapper = styled.div`
-  width: 100%;
-  cursor: pointer;
-`
-
-// 直接样式化 Slider 组件，无容器包装
-const StyledSlider = styled(Slider)<{
+// Netflix 风格进度条容器
+const ProgressContainer = styled.div<{
+  $isVisible: boolean
   $isHovering: boolean
   $isDragging: boolean
-  $token: any
 }>`
-  /* 增加选择器特异性来覆盖 Ant Design 的默认变量 */
-  &.ant-slider {
-    --ant-slider-rail-size: 1px !important; /* 轨道基础尺寸 */
-  }
-
-  /* 重置所有默认margin/padding */
-  margin: 0 !important;
-  padding: 0 !important;
+  position: relative;
   width: 100%;
+  height: ${COMPONENT_TOKENS.PROGRESS_BAR.INTERACTION_AREA_HEIGHT}px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 
-  .ant-slider-horizontal {
-    height: 0px; /* 移除默认高度 */
+  /* 鼠标交互区域 */
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+  }
+`
+
+// 缓冲进度条
+const BufferTrack = styled.div<{ $progress: number }>`
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: ${(props) => props.$progress}%;
+  height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HIDDEN}px;
+  background: var(--ant-color-text-tertiary, rgba(255, 255, 255, 0.3));
+  opacity: ${COMPONENT_TOKENS.PROGRESS_BAR.BUFFER_OPACITY};
+  border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px;
+  transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_SMOOTH};
+  z-index: 1;
+
+  /* 悬停时与主轨道同步增大 */
+  ${ProgressContainer}:hover & {
+    height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px;
   }
 
-  /* 轨道样式 - 默认状态 - 使用主题令牌 */
-  .ant-slider-rail {
-    background: var(--color-border);
-    opacity: ${COMPONENT_TOKENS.PROGRESS_BAR.RAIL_OPACITY_BASE};
-    height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_BASE}px;
-    transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_DURATION_BASE}
-      ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_EASING};
-  }
-
-  /* 进度轨道样式 - 已播放部分 - 使用主题令牌 */
-  .ant-slider-track {
-    background: var(--color-primary);
-    height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_BASE}px;
-    transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_DURATION_BASE}
-      ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_EASING};
-    box-shadow: 0 0 ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW_BLUR_BASE}px var(--color-primary);
-    filter: opacity(0.9);
-  }
-
-  /* 手柄样式 - 沉浸式设计，与进度条统一 - 默认隐藏 - 使用主题令牌 */
-  .ant-slider-handle {
-    width: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SIZE_BASE}px;
-    height: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SIZE_BASE}px;
-    /* 使用渐变色，从主色到半透明白色 - 透明度来自主题令牌 */
-    background: radial-gradient(
-      circle,
-      var(--color-primary) 0%,
-      rgba(255, 255, 255, ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_GRADIENT_INNER}) 70%,
-      rgba(255, 255, 255, ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_GRADIENT_OUTER}) 100%
-    );
-    /* 边框使用主题令牌透明度 */
-    border: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_BASE}px solid
-      rgba(
-        var(--color-primary-rgb, 59, 130, 246),
-        ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_ALPHA}
-      );
-    /* 使用主题令牌的光晕阴影 */
-    box-shadow:
-      0 0 ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW_BLUR_BASE}px
-        rgba(
-          var(--color-primary-rgb, 59, 130, 246),
-          ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW_ALPHA_BASE}
-        ),
-      0 ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW_OFFSET}px 8px rgba(0, 0, 0, 0.1);
-    transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_DURATION_SLOW}
-      ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_EASING};
-    /* 默认完全隐藏 - 使用主题令牌缩放 */
-    opacity: 0;
-    transform: scale(${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SCALE_HIDDEN});
-    cursor: pointer;
-
-    /* 移除默认的伪元素 */
-    &::after {
-      display: none !important;
-    }
-
-    /* 移除默认的方形边框 */
-    &::before {
-      display: none !important;
-    }
-
-    /* 手柄激活状态 - 使用主题令牌 */
-    &:focus {
-      border-color: var(--color-primary);
-      background: radial-gradient(
-        circle,
-        var(--color-primary) 0%,
-        rgba(255, 255, 255, ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_GRADIENT_INNER}) 70%,
-        rgba(255, 255, 255, ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_GRADIENT_OUTER}) 100%
-      );
-      box-shadow:
-        0 0 ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW_BLUR_BASE + 2}px
-          rgba(var(--color-primary-rgb, 59, 130, 246), 0.5),
-        0 3px 8px rgba(0, 0, 0, 0.15);
-    }
-  }
-
-  /* 基于props的条件样式 - 悬停时显示handler - 使用主题令牌 */
-  ${(props) =>
-    (props.$isHovering || props.$isDragging) &&
-    `
-    .ant-slider-handle {
-      opacity: 1 !important;
-      transform: scale(${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SCALE_HOVER}) !important;
-      width: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SIZE_HOVER}px !important;
-      height: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SIZE_HOVER}px !important;
-      margin-left: -${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SIZE_HOVER / 2}px !important;
-      /* 悬停时增强渐变效果 */
-      background: radial-gradient(
-        circle,
-        var(--color-primary) 0%,
-        rgba(255, 255, 255, 0.95) 60%,
-        rgba(255, 255, 255, 0.8) 100%
-      ) !important;
-      border: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_HOVER}px solid rgba(var(--color-primary-rgb, 59, 130, 246), ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_ALPHA_HOVER}) !important;
-      /* 增强光晕效果与进度条呼应 */
-      box-shadow:
-        0 0 ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW_BLUR_HOVER}px rgba(var(--color-primary-rgb, 59, 130, 246), ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW_ALPHA_HOVER}),
-        0 3px 12px rgba(0, 0, 0, 0.15) !important;
-    }
-    .ant-slider-rail {
-      height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px !important;
-      border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px !important;
-      opacity: ${COMPONENT_TOKENS.PROGRESS_BAR.RAIL_OPACITY_HOVER} !important;
-    }
-    .ant-slider-track {
-      height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px !important;
-      border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px !important;
-      box-shadow: 0 0 ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_SHADOW_BLUR_HOVER}px var(--color-primary) !important;
-      filter: opacity(1) !important;
-    }
-  `}
-
-  /* 悬停整个进度条时的效果 - 仅轨道变化，handler通过props控制 - 使用主题令牌 */
-  &:hover {
-    .ant-slider-rail {
-      background: var(--color-border);
-      opacity: ${COMPONENT_TOKENS.PROGRESS_BAR.RAIL_OPACITY_HOVER};
-      height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px;
-      border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px;
-    }
-
-    .ant-slider-track {
-      height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px;
-      border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px;
-      box-shadow: 0 0 ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_SHADOW_BLUR_HOVER}px
-        var(--color-primary);
-      filter: opacity(1);
-    }
-  }
-
-  /* 禁用状态 */
-  &.ant-slider-disabled {
-    .ant-slider-rail {
-      background: var(--color-border);
-      opacity: 0.1;
-    }
-
-    .ant-slider-track {
-      background: var(--color-text-3);
-      box-shadow: none;
-      filter: none;
-    }
-
-    .ant-slider-handle {
-      background: rgba(255, 255, 255, 0.3); /* 禁用时半透明白色 */
-      border: 2px solid rgba(255, 255, 255, 0.3);
-      box-shadow: none;
-      filter: none;
-      border-radius: 50% !important;
-    }
-  }
-
-  /* Tooltip 优化 */
-  + .ant-tooltip {
-    .ant-tooltip-inner {
-      background: var(--color-background-soft);
-      opacity: 0.95;
-      backdrop-filter: blur(8px);
-      border-radius: 4px;
-      font-size: 11px;
-      padding: 4px 8px;
-      color: var(--color-text-1);
-      border: 1px solid var(--color-border);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    }
-
-    .ant-tooltip-arrow {
-      &::before {
-        background: var(--color-background-soft);
-        border: 1px solid var(--color-border);
-      }
-    }
-  }
-
-  /* 主题适配 - 确保沉浸式设计在所有主题下都和谐 - 使用主题令牌 */
-  [theme-mode='dark'] & {
-    .ant-slider-handle {
-      /* 暗色主题下的渐变调整 */
-      background: radial-gradient(
-        circle,
-        var(--color-primary) 0%,
-        rgba(255, 255, 255, 0.95) 70%,
-        rgba(255, 255, 255, 0.8) 100%
-      ) !important;
-      border: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_BASE}px solid
-        rgba(var(--color-primary-rgb, 59, 130, 246), 0.7) !important;
-      border-radius: 50% !important;
-    }
-  }
-
+  /* 主题适配 */
   [theme-mode='light'] & {
-    .ant-slider-handle {
-      /* 亮色主题下的渐变调整 */
-      background: radial-gradient(
-        circle,
-        var(--color-primary) 0%,
-        rgba(255, 255, 255, ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_GRADIENT_INNER}) 70%,
-        rgba(255, 255, 255, ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_GRADIENT_OUTER}) 100%
-      ) !important;
-      border: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_BASE}px solid
-        rgba(
-          var(--color-primary-rgb, 59, 130, 246),
-          ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_ALPHA}
-        ) !important;
-      border-radius: 50% !important;
-    }
+    background: var(--ant-color-text-tertiary, rgba(0, 0, 0, 0.1));
+  }
 
-    .ant-slider-rail {
-      background: var(--color-border);
-      opacity: 0.2;
-    }
+  [theme-mode='dark'] & {
+    background: var(--ant-color-text-tertiary, rgba(255, 255, 255, 0.3));
+  }
+`
+
+// 主进度轨道
+const ProgressTrack = styled.div`
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HIDDEN}px;
+  background: var(--ant-color-border, rgba(255, 255, 255, 0.2));
+  opacity: ${COMPONENT_TOKENS.PROGRESS_BAR.RAIL_OPACITY_BASE};
+  border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px;
+  transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_SMOOTH};
+  z-index: 2;
+
+  /* 悬停时增大 */
+  ${ProgressContainer}:hover & {
+    height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px;
+    opacity: ${COMPONENT_TOKENS.PROGRESS_BAR.RAIL_OPACITY_HOVER};
+  }
+
+  /* 主题适配 */
+  [theme-mode='light'] & {
+    background: var(--ant-color-border, rgba(0, 0, 0, 0.15));
+  }
+
+  [theme-mode='dark'] & {
+    background: var(--ant-color-border, rgba(255, 255, 255, 0.2));
+  }
+`
+
+// 已播放进度填充
+const ProgressFill = styled.div<{ $progress: number }>`
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: ${(props) => props.$progress}%;
+  height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HIDDEN}px;
+  background: ${COMPONENT_TOKENS.PROGRESS_BAR.PROGRESS_GRADIENT};
+  border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px;
+  transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_SMOOTH};
+  z-index: 3;
+
+  /* Netflix 的经典光晕效果 */
+  box-shadow: ${COMPONENT_TOKENS.PROGRESS_BAR.PROGRESS_GLOW};
+
+  /* 悬停时增大并增强光晕 */
+  ${ProgressContainer}:hover & {
+    height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px;
+    box-shadow: ${COMPONENT_TOKENS.PROGRESS_BAR.PROGRESS_GLOW_HOVER};
+  }
+`
+
+// 进度手柄
+const ProgressHandle = styled.div<{
+  $progress: number
+  $isVisible: boolean
+}>`
+  position: absolute;
+  top: 50%;
+  left: ${(props) => props.$progress}%;
+  transform: translate(-50%, -50%);
+  width: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SIZE_HOVER}px;
+  height: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SIZE_HOVER}px;
+  background: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_GRADIENT};
+  border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_BORDER_RADIUS};
+  box-shadow: ${COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SHADOW};
+  opacity: ${(props) =>
+    props.$isVisible
+      ? COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_OPACITY_HOVER
+      : COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_OPACITY_BASE};
+  transform: translate(-50%, -50%)
+    scale(
+      ${(props) =>
+        props.$isVisible
+          ? COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SCALE_HOVER
+          : COMPONENT_TOKENS.PROGRESS_BAR.HANDLE_SCALE_HIDDEN}
+    );
+  transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_ELASTIC};
+  z-index: 4;
+`
+
+// 时间预览提示
+const TimePreview = styled.div<{ $show: boolean }>`
+  position: absolute;
+  top: -35px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: ${COMPONENT_TOKENS.PROGRESS_BAR.TIME_FONT_SIZE}px;
+  font-weight: 500;
+  white-space: nowrap;
+  opacity: ${(props) => (props.$show ? COMPONENT_TOKENS.PROGRESS_BAR.TIME_OPACITY : 0)};
+  transform: translateX(-50%) translateY(${(props) => (props.$show ? 0 : 5)}px);
+  transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_FAST};
+  pointer-events: none;
+  z-index: 5;
+
+  /* 小三角箭头 */
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+    border-top-color: rgba(0, 0, 0, 0.8);
   }
 `

--- a/src/renderer/src/pages/player/components/ProgressBar.tsx
+++ b/src/renderer/src/pages/player/components/ProgressBar.tsx
@@ -16,7 +16,7 @@ function ProgressBar() {
   const duration = usePlayerStore((s) => s.duration)
   const { seekToUser } = usePlayerCommands()
 
-  // Netflix 风格状态管理
+  // 进度条状态管理
   const [isHovering, setIsHovering] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
   const [isVisible, setIsVisible] = useState(false)
@@ -28,7 +28,7 @@ function ProgressBar() {
   const hideTimeoutRef = useRef<number | null>(null)
   const dragStartRef = useRef(false)
 
-  // Netflix 风格自动隐藏逻辑
+  // 自动隐藏逻辑
   useEffect(() => {
     if (isHovering || isDragging) {
       setIsVisible(true)
@@ -185,7 +185,6 @@ const ProgressContainer = styled.div<{
 }>`
   position: relative;
   width: 100%;
-  height: ${COMPONENT_TOKENS.PROGRESS_BAR.INTERACTION_AREA_HEIGHT}px;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -209,17 +208,11 @@ const BufferTrack = styled.div<{ $progress: number }>`
   top: 50%;
   transform: translateY(-50%);
   width: ${(props) => props.$progress}%;
-  height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HIDDEN}px;
   background: var(--ant-color-text-tertiary, rgba(255, 255, 255, 0.3));
   opacity: ${COMPONENT_TOKENS.PROGRESS_BAR.BUFFER_OPACITY};
   border-radius: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_BORDER_RADIUS}px;
   transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_SMOOTH};
   z-index: 1;
-
-  /* 悬停时与主轨道同步增大 */
-  ${ProgressContainer}:hover & {
-    height: ${COMPONENT_TOKENS.PROGRESS_BAR.TRACK_HEIGHT_HOVER}px;
-  }
 
   /* 主题适配 */
   [theme-mode='light'] & {
@@ -274,7 +267,7 @@ const ProgressFill = styled.div<{ $progress: number }>`
   transition: all ${COMPONENT_TOKENS.PROGRESS_BAR.TRANSITION_SMOOTH};
   z-index: 3;
 
-  /* Netflix 的经典光晕效果 */
+  /* 主题色光晕效果 */
   box-shadow: ${COMPONENT_TOKENS.PROGRESS_BAR.PROGRESS_GLOW};
 
   /* 悬停时增大并增强光晕 */


### PR DESCRIPTION
## Summary
- Remove green glow effect from Netflix-style progress bar for cleaner design
- Replace progress bar glow effects with 'none' value
- Maintain all other visual effects and functionality

## Changes Made
- **PROGRESS_GLOW**: Changed from `0 0 8px rgba(0, 185, 107, 0.4)` to `'none'`
- **PROGRESS_GLOW_HOVER**: Changed from `0 0 12px rgba(0, 185, 107, 0.6)` to `'none'`

## Test Plan
- [x] Verify progress bar still functions normally
- [x] Confirm glow effect is removed in both normal and hover states
- [x] Check that other progress bar styling remains intact
- [x] Test on both light and dark themes

## Visual Impact
This change removes the distracting green glow effect while preserving all other progress bar functionality and styling, resulting in a more minimalist and clean user interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Redesigned, Netflix-style progress bar with smoother animations and glow.
  * Click-to-seek and drag-to-seek interactions with improved precision.
  * Hover reveal with auto-hide behavior for a cleaner viewing experience.
  * Buffer indicator displayed behind the main progress.
  * Time preview tooltip on hover for easier navigation.

* Style
  * Enhanced theming: refined sizes, rounded corners, gradients, opacities, and shadows across hover/active states.
  * Consistent visual tokens for handle, track, buffering, and time display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->