### PR TITLE
feat: optimize media-server build output to resources directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ docs/.vitepress/cache/deps
 dist-test
 
 resources/ffmpeg/
+resources/media-server
 .ffmpeg-cache

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -51,6 +51,84 @@ export default defineConfig({
             }
           }
         }
+      },
+      {
+        name: 'copy-media-server',
+        generateBundle() {
+          // 复制 backend 到 resources/media-server
+          const srcDir = path.resolve('backend')
+          const destDir = path.resolve('resources/media-server')
+
+          // 检查源目录是否存在
+          if (!fs.existsSync(srcDir)) {
+            console.warn('⚠️  backend 目录不存在，跳过复制')
+            return
+          }
+
+          // 需要排除的文件和目录
+          const excludePatterns = [
+            '__pycache__',
+            '.pyc',
+            '.pyo',
+            '.pyd',
+            '.venv',
+            'venv',
+            'env',
+            '.git',
+            '.gitignore',
+            'cache',
+            '.vscode',
+            '.idea',
+            '.egg-info',
+            'dist',
+            'build',
+            '.pytest_cache',
+            '.mypy_cache',
+            '.ruff_cache',
+            'uv.lock',
+            '.DS_Store',
+            'assets'
+          ]
+
+          // 检查是否应排除
+          const shouldExclude = (filePath: string): boolean => {
+            const basename = path.basename(filePath)
+            return excludePatterns.some((pattern) => {
+              if (pattern.startsWith('.') && !pattern.includes('_')) {
+                return basename.endsWith(pattern) || basename === pattern
+              }
+              return basename.includes(pattern)
+            })
+          }
+
+          // 递归复制目录
+          const copyDir = (src: string, dest: string) => {
+            if (!fs.existsSync(dest)) {
+              fs.mkdirSync(dest, { recursive: true })
+            }
+
+            const entries = fs.readdirSync(src, { withFileTypes: true })
+
+            for (const entry of entries) {
+              const srcPath = path.join(src, entry.name)
+              const destPath = path.join(dest, entry.name)
+
+              if (shouldExclude(srcPath)) {
+                continue
+              }
+
+              if (entry.isDirectory()) {
+                copyDir(srcPath, destPath)
+              } else if (entry.isFile()) {
+                fs.copyFileSync(srcPath, destPath)
+              }
+            }
+          }
+
+          // 执行复制
+          console.log('📦 复制 Media Server 到 resources/media-server/')
+          copyDir(srcDir, destDir)
+        }
       }
     ],
     resolve: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@sentry/electron':
         specifier: ^5.12.0
         version: 5.12.0
-      '@types/hls.js':
-        specifier: ^1.0.0
-        version: 1.0.0
       antd:
         specifier: ^5.27.3
         version: 5.27.3(moment@2.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -144,6 +141,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
+      '@types/hls.js':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/node':
         specifier: ^22.18.1
         version: 22.18.1


### PR DESCRIPTION
## Summary

- Optimize media-server build output location from `out/resources/media-server` to `resources/media-server`
- Exclude assets directory from media-server copy to reduce build size
- Update .gitignore to exclude the new resources/media-server directory

## Changes

### Build Configuration (`electron.vite.config.ts`)
- Changed media-server output directory from `out/resources/media-server` to `resources/media-server`
- Added `assets` directory to exclusion patterns
- Updated console logs to reflect new path

### Git Configuration (`.gitignore`)
- Added `resources/media-server` to ignore list

## Test Plan

- [x] Verify build completes successfully
- [x] Confirm media-server files are copied to correct location
- [x] Validate assets directory is excluded from copy
- [x] Check git status doesn't show media-server files

## Benefits

- Cleaner build structure with media-server in resources directory
- Reduced build artifacts by excluding unnecessary assets
- Better separation between build outputs and resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)